### PR TITLE
[codex] Optimize voice packet paths

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -73,7 +73,7 @@ jobs:
         run: |
           uv run --no-sync python -m pip install --force-reinstall dist/*.whl
           if [[ "${{ matrix.python-version }}" == *t ]]; then export PYTHON_GIL=0; fi
-          uv run --no-sync python -c "import asyncio, pyarrow as pa; asyncio.set_event_loop(asyncio.new_event_loop()); from discord.ext import songbird; from discord.ext.songbird import player; assert not hasattr(songbird, 'SupportedCodec'); player.AudioInput(pa.array([1, 2, 3], type=pa.uint8())); player.RawPCMInput(pa.array([0.0, 0.0], type=pa.float32()), sample_rate=48000, channels=2); player.StreamInput(asyncio.StreamReader())"
+          uv run --no-sync python -c "import asyncio, pyarrow as pa; asyncio.set_event_loop(asyncio.new_event_loop()); from discord.ext import songbird; from discord.ext.songbird import player; assert not hasattr(songbird, 'SupportedCodec'); player.AudioInput(pa.array([1, 2, 3], type=pa.uint8())); player.RawPCMInput(pa.array([0.0, 0.0], type=pa.float32()), sample_rate=48000, channels=2); player.StreamInput(asyncio.StreamReader()); player.OpusPacketInput(pa.array([b'\xf8\xff\xfe'], type=pa.binary())); player.OpusPacketStreamInput(max_packets=1); assert 'opus' in player.supported_codecs()"
 
       - name: Upload wheels
         uses: actions/upload-artifact@v4
@@ -200,7 +200,7 @@ jobs:
         run: |
           uv run --no-sync python -m pip install --force-reinstall dist/*.whl
           if [[ "${{ matrix.python-version }}" == *t ]]; then export PYTHON_GIL=0; fi
-          uv run --no-sync python -c "import asyncio, pyarrow as pa; asyncio.set_event_loop(asyncio.new_event_loop()); from discord.ext import songbird; from discord.ext.songbird import player; assert not hasattr(songbird, 'SupportedCodec'); player.AudioInput(pa.array([1, 2, 3], type=pa.uint8())); player.RawPCMInput(pa.array([0.0, 0.0], type=pa.float32()), sample_rate=48000, channels=2); player.StreamInput(asyncio.StreamReader())"
+          uv run --no-sync python -c "import asyncio, pyarrow as pa; asyncio.set_event_loop(asyncio.new_event_loop()); from discord.ext import songbird; from discord.ext.songbird import player; assert not hasattr(songbird, 'SupportedCodec'); player.AudioInput(pa.array([1, 2, 3], type=pa.uint8())); player.RawPCMInput(pa.array([0.0, 0.0], type=pa.float32()), sample_rate=48000, channels=2); player.StreamInput(asyncio.StreamReader()); player.OpusPacketInput(pa.array([b'\xf8\xff\xfe'], type=pa.binary())); player.OpusPacketStreamInput(max_packets=1); assert 'opus' in player.supported_codecs()"
       - name: Upload wheels
         uses: actions/upload-artifact@v4
         with:
@@ -278,7 +278,7 @@ jobs:
         run: |
           uv run --no-sync python -m pip install --force-reinstall dist/*.whl
           if [[ "${{ matrix.python-version }}" == *t ]]; then export PYTHON_GIL=0; fi
-          uv run --no-sync python -c "import asyncio, pyarrow as pa; asyncio.set_event_loop(asyncio.new_event_loop()); from discord.ext import songbird; from discord.ext.songbird import player; assert not hasattr(songbird, 'SupportedCodec'); player.AudioInput(pa.array([1, 2, 3], type=pa.uint8())); player.RawPCMInput(pa.array([0.0, 0.0], type=pa.float32()), sample_rate=48000, channels=2); player.StreamInput(asyncio.StreamReader())"
+          uv run --no-sync python -c "import asyncio, pyarrow as pa; asyncio.set_event_loop(asyncio.new_event_loop()); from discord.ext import songbird; from discord.ext.songbird import player; assert not hasattr(songbird, 'SupportedCodec'); player.AudioInput(pa.array([1, 2, 3], type=pa.uint8())); player.RawPCMInput(pa.array([0.0, 0.0], type=pa.float32()), sample_rate=48000, channels=2); player.StreamInput(asyncio.StreamReader()); player.OpusPacketInput(pa.array([b'\xf8\xff\xfe'], type=pa.binary())); player.OpusPacketStreamInput(max_packets=1); assert 'opus' in player.supported_codecs()"
       - name: Upload wheels
         uses: actions/upload-artifact@v4
         with:
@@ -308,6 +308,9 @@ jobs:
       - name: Test sdist
         run: |
           uv run --no-sync python -m pip install dist/*.tar.gz
+      - name: Test sdist minimal codec build
+        run: |
+          uv run --no-sync python -m pip install --force-reinstall dist/*.tar.gz --config-settings="maturin.build-args=--no-default-features --features codec-minimal"
       - name: Upload sdist
         uses: actions/upload-artifact@v4
         with:

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -966,6 +966,7 @@ dependencies = [
  "futures",
  "log",
  "nonmax",
+ "opus2",
  "pin-project-lite",
  "pyo3",
  "pyo3-arrow",
@@ -4282,9 +4283,12 @@ dependencies = [
  "symphonia-bundle-mp3",
  "symphonia-codec-aac",
  "symphonia-codec-adpcm",
+ "symphonia-codec-alac",
  "symphonia-codec-pcm",
  "symphonia-codec-vorbis",
  "symphonia-core",
+ "symphonia-format-caf",
+ "symphonia-format-isomp4",
  "symphonia-format-mkv",
  "symphonia-format-ogg",
  "symphonia-format-riff",
@@ -4337,6 +4341,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "symphonia-codec-alac"
+version = "0.5.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8413fa754942ac16a73634c9dfd1500ed5c61430956b33728567f667fdd393ab"
+dependencies = [
+ "log",
+ "symphonia-core",
+]
+
+[[package]]
 name = "symphonia-codec-pcm"
 version = "0.5.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4369,6 +4383,30 @@ dependencies = [
  "lazy_static",
  "log",
  "rustfft",
+]
+
+[[package]]
+name = "symphonia-format-caf"
+version = "0.5.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8faf379316b6b6e6bbc274d00e7a592e0d63ff1a7e182ce8ba25e24edd3d096"
+dependencies = [
+ "log",
+ "symphonia-core",
+ "symphonia-metadata",
+]
+
+[[package]]
+name = "symphonia-format-isomp4"
+version = "0.5.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "243739585d11f81daf8dac8d9f3d18cc7898f6c09a259675fc364b382c30e0a5"
+dependencies = [
+ "encoding_rs",
+ "log",
+ "symphonia-core",
+ "symphonia-metadata",
+ "symphonia-utils-xiph",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,10 +23,32 @@ crate-type = ["cdylib", "rlib"]
 name = "stub_gen"
 doc = false
 
+[features]
+default = ["codec-full"]
+codec-full = ["symphonia/all", "codec-simd"]
+codec-minimal = ["codec-pcm", "format-wav"]
+codec-simd = ["symphonia/opt-simd"]
+codec-aac = ["symphonia/aac"]
+codec-adpcm = ["symphonia/adpcm"]
+codec-alac = ["symphonia/alac"]
+codec-flac = ["symphonia/flac"]
+codec-mp1 = ["symphonia/mp1"]
+codec-mp2 = ["symphonia/mp2"]
+codec-mp3 = ["symphonia/mp3"]
+codec-pcm = ["symphonia/pcm"]
+codec-vorbis = ["symphonia/vorbis"]
+format-aiff = ["symphonia/aiff"]
+format-caf = ["symphonia/caf"]
+format-isomp4 = ["symphonia/isomp4"]
+format-mkv = ["symphonia/mkv"]
+format-ogg = ["symphonia/ogg"]
+format-wav = ["symphonia/wav"]
+
 [dependencies]
 arrow = {version = "58.3.0"}
 log = "0.4.29"
 nonmax = "0.5.5"
+opus2 = "0.4.0"
 pyo3 = { version = "0.28.3", features = ["experimental-async"] }
 pyo3-log = "0.13.3"
 pyo3-async-runtimes = { version = "0.28.0", features = ["tokio", "tokio-runtime"] }
@@ -36,7 +58,7 @@ songbird = { version = "0.6.0", features = ["receive", "driver", "tws", "rustls"
 tokio = {version = "1.48.0", features = ["macros", "sync"]}
 async-trait = "0.1.83"
 dashmap = "6.1.0"
-symphonia = { features = ["wav", "pcm", "mp3", "opt-simd", "aac"], version = "0.5.5" }
+symphonia = { version = "0.5.5", default-features = false }
 env_logger = "0.11.8"
 tokio-stream = {version = "0.1.17", features = ["full"]}
 async-stream = "0.3.6"

--- a/README.md
+++ b/README.md
@@ -76,10 +76,15 @@ Native input types are exported from `discord.ext.songbird.player`.
 - `RawPCMInput`: `pyarrow.Float32Array` PCM input
 - `AudioInput`: encoded audio in a `pyarrow.Array`
 - `StreamInput`: `asyncio.StreamReader`
+- `OpusPacketInput`: pre-encoded 20 ms Opus frames in a `pyarrow.BinaryArray`
+- `OpusPacketStreamInput`: live pre-encoded 20 ms Opus packet stream
 
 `AudioInput` and `StreamInput` no longer take a codec argument. Songbird 0.6
 detects encoded stream formats internally, so `SupportedCodec` has been removed
 from the Python API.
+For Ogg/WebM/DCA Opus sources, Songbird may use Opus passthrough internally.
+For raw Opus packets, use `OpusPacketInput` or `OpusPacketStreamInput`.
+Passthrough requires a single active track, 20 ms Opus frames, and volume `1.0`.
 
 ```python
 import asyncio
@@ -88,6 +93,15 @@ from discord.ext.songbird import player
 buffer = asyncio.StreamReader()
 source = player.StreamInput(buffer)
 track = player.Track(source)
+```
+
+```python
+import pyarrow as pa
+from discord.ext.songbird import player
+
+frames = pa.array([opus_frame_0, opus_frame_1], type=pa.binary())
+source = player.OpusPacketInput(frames)
+track = player.Track(source)  # keep volume at 1.0 for passthrough
 ```
 
 ### Voice receive
@@ -100,13 +114,21 @@ from discord.ext.songbird import receive
 sink = receive.BufferSink(max_duration_secs=5)
 vc.listen(sink)
 
-async for tick in sink:
-    pcm = tick.get(receive.VoiceKey.User(user_id))
+async for batch in sink:
+    # batch is a pyarrow.RecordBatch with key_kind, key_id, speaking, and pcm columns
+    handle_batch(batch)
+
+async for pcm in sink[receive.VoiceKey.User(user_id)]:
     if pcm is not None:
         handle_pcm(pcm)
 ```
 
-`VoiceTick.get()` returns `pyarrow.Int16Array` (PCM).
+Receive iteration is columnar. The `pcm` column is `list<int16>` and stores all
+speaking users for a tick in one shared Arrow buffer. Per-key convenience
+iteration still returns `pyarrow.Int16Array | None`.
+SSRC to user ID mapping is tracked at the voice connection level from
+Songbird's speaking updates, so `VoiceKey.Unknown(ssrc)` is limited to packets
+seen before Discord has exposed that mapping.
 
 ## Examples
 
@@ -128,6 +150,14 @@ Published CPython wheels are split by ABI. The release workflow builds regular
 `cp314` wheels and free-threaded `cp314t` wheels for the supported platforms, so
 a normal Python 3.14 environment installs the regular wheel while Python 3.14t
 installs the free-threaded wheel.
+Published wheels are built with the full Symphonia codec/format set enabled.
+Rust codec features are compile-time options, so installed wheels cannot switch
+codec sets at runtime. For a smaller source build, pass Cargo features through
+Maturin:
+
+```bash
+pip install . --config-settings="maturin.build-args=--no-default-features --features codec-minimal"
+```
 
 ## Development
 

--- a/docs/receive.md
+++ b/docs/receive.md
@@ -1,14 +1,15 @@
 # Receive (Voice Input)
 
-This document describes the **current** voice receive API in `discord-ext-songbird`.
-The public Python surface is re-exported from `discord.ext.songbird.receive`, which is backed by the
-native module `discord.ext.songbird.native.receive`.
+This document describes the voice receive API in `discord-ext-songbird`.
+The public Python surface is re-exported from `discord.ext.songbird.receive`,
+which is backed by the native module `discord.ext.songbird.native.receive`.
 
 ## Overview
 
-- Voice receive is done by registering a **sink** with `SongbirdClient.listen()`.
+- Voice receive is done by registering a sink with `SongbirdClient.listen()`.
 - Two sinks are available from Python: `BufferSink` and `StreamSink`.
-- Incoming audio is buffered as **VoiceTick** snapshots and consumed with `async for`.
+- Incoming audio is exposed as Arrow `RecordBatch` snapshots and consumed with `async for`.
+- Per-key convenience iterators are still available when only one source is needed.
 
 ## Quick Start
 
@@ -28,21 +29,27 @@ vc.listen(sink)  # non-async
 await asyncio.sleep(5)
 sink.stop()
 
-async for tick in sink:
-    key = receive.VoiceKey.User(user_id)
-    pcm = tick.get(key)
+async for batch in sink:
+    # batch is a pyarrow.RecordBatch
+    # columns: key_kind, key_id, speaking, pcm
+    handle_batch(batch)
+```
+
+For single-source consumers:
+
+```python
+key = receive.VoiceKey.User(user_id)
+async for pcm in sink[key]:
     if pcm is not None:
-        # pcm is a pyarrow.Int16Array (16-bit PCM)
+        # pcm is a pyarrow.Int16Array slice backed by the tick's shared PCM buffer
         handle_pcm(pcm)
-    elif tick.is_silent(key):
-        # key was present but silent for this tick
-        pass
 ```
 
 ## StreamSink (Streaming)
 
-`StreamSink` provides a stream-based API using a broadcast channel. Unlike `BufferSink`,
-it is designed for concurrent consumers and supports retaining ticks when no streams are active.
+`StreamSink` provides a stream-based API using a broadcast channel. It supports
+concurrent consumers via permits and can optionally retain recent ticks when no
+streams are active.
 
 ```python
 from discord.ext import songbird
@@ -53,41 +60,58 @@ sink = receive.StreamSink(retain=True, retain_secs=15, max_concurrent=50)
 vc.listen(sink)
 
 async with sink.stream() as stream:
-    async for tick in stream:
-        pcm = tick.get(receive.VoiceKey.User(user_id))
-        if pcm is not None:
-            handle_pcm(pcm)
+    async for batch in stream:
+        handle_batch(batch)
 ```
+
+## Arrow Batch Schema
+
+Each receive tick is represented as one Arrow `RecordBatch`:
+
+| column | type | meaning |
+| --- | --- | --- |
+| `key_kind` | `uint8` | `0` for user IDs, `1` for unknown SSRCs |
+| `key_id` | `uint64` | Discord user ID or SSRC value |
+| `speaking` | `bool` | `True` when this row has PCM for the tick |
+| `pcm` | `list<int16>` | Interleaved 16-bit PCM samples; silent rows use an empty list |
+
+This keeps all PCM for a tick in a single Arrow values buffer. The per-key
+helpers return zero-copy slices from that shared buffer where possible.
 
 ## How It Works (Technical)
 
-At runtime, Songbird emits voice events (e.g., `VoiceTick`, `SpeakingStateUpdate`) from the voice
-driver. The receive layer attaches a sink-specific event handler and converts raw tick data into
-Python-facing structures.
+At runtime, Songbird emits voice events from the voice driver. The receive layer
+maintains a connection-level SSRC to user ID map and converts raw tick data into
+a compact columnar Arrow batch.
 
 Key points:
 
-- **Tick cadence**: one tick represents ~20 ms of audio (≈ 50 ticks/sec).
-- **Source mapping**: `SpeakingStateUpdate` is used to map SSRC → user ID.
-- **Tick conversion**:
-  - speaking entries with `decoded_voice` are converted to `pyarrow.Int16Array` PCM
-  - entries without `decoded_voice` (or in the silent list) are marked silent
-- **Delivery**:
-  - `BufferSink` stores `VoiceTick` in a queue and is consumed destructively
-  - `StreamSink` pushes `VoiceTick` through a broadcast channel for concurrent consumers
+- One tick represents about 20 ms of audio, or roughly 50 ticks/sec.
+- `SpeakingStateUpdate` maps SSRC values to Discord user IDs at the voice
+  connection level, so later sinks can reuse mappings observed before `listen()`.
+- Entries with `decoded_voice` append their PCM into the shared `pcm` values buffer.
+- Entries without `decoded_voice`, and SSRCs in the silent set, become silent rows.
+- `BufferSink` stores batches in a queue and is consumed destructively.
+- `StreamSink` broadcasts `Arc`-shared batches for concurrent consumers.
 
-### Data Flow (Simplified)
+### Data Flow
 
-```
+```text
 Discord Voice -> Songbird driver
                      |
                      v
-      SpeakingStateUpdate / VoiceTick events
+      SpeakingStateUpdate / ClientDisconnect
+                     |
+                     v
+        Connection VoiceIdentityMap
+                     |
+                     v
+             VoiceTick events
                      |
                      v
             Receive Sink Handler
-            - SSRC → User ID map
-            - Build VoiceTick
+            - Build VoiceTickBatch
+            - Canonical Arrow RecordBatch
                      |
          +-----------+-----------+
          |                       |
@@ -96,72 +120,32 @@ Discord Voice -> Songbird driver
    (VecDeque queue)     (broadcast channel)
          |                       |
          v                       v
-   async for tick          async with stream
-   async for pcm           async for tick/pcm
+   async for batch        async with stream
+   async for pcm          async for batch/pcm
 ```
-
-## Data Model
-
-### VoiceKey
-
-Identifies the source of audio.
-
-- `VoiceKey.User(user_id)` for known user IDs
-- `VoiceKey.Unknown(ssrc)` when only SSRC is known
-
-### VoiceTick
-
-A snapshot for a single tick.
-
-- `VoiceTick.get(key)` → `Optional[pyarrow.Int16Array]`
-  - Returns PCM only when the key is speaking in this tick.
-  - Returns `None` if the key is silent or not present in this tick.
-- `VoiceTick.is_silent(key)` → `bool`
-  - `True` if the key is marked silent in this tick.
-- `VoiceTick.all_keys()` → `set[VoiceKey]`
-  - All keys present in this tick (speaking + silent).
-- `VoiceTick.speaking_keys()` → `set[VoiceKey]`
-  - Keys with PCM data in this tick.
-- `VoiceTick.silent_keys()` → `set[VoiceKey]`
-  - Keys marked silent in this tick.
 
 ## BufferSink Behavior
 
-`BufferSink` accumulates `VoiceTick` entries in an internal queue.
+`BufferSink` accumulates Arrow `RecordBatch` entries in an internal queue.
 
-- **Register**: `vc.listen(sink)` subscribes to Songbird `VoiceTick` and `SpeakingStateUpdate` events.
-- **Stop**: `sink.stop()` stops further buffering (the sink remains registered).
-- **Consume**:
-  - `async for tick in sink:` yields `VoiceTick` entries.
-  - `async for pcm in sink[VoiceKey.User(user_id)]:` yields `pyarrow.Int16Array | None` for a specific key.
-- **Consumption is destructive**: ticks are popped from the queue and cannot be read again.
-- **No waiting**: iteration ends when the queue is empty; it does not block for new ticks.
-- **Buffer limit**:
-  - `max_duration_secs` caps the buffer window in seconds (keyword-only).
-  - `drop_oldest` is keyword-only.
-  - `drop_oldest` controls whether old ticks are discarded when full.
-  - Implementation detail: it is converted to a tick count based on **20 ms per tick** (50 ticks/sec),
-    so the initial capacity is `max_duration_secs * 50`.
+- `vc.listen(sink)` subscribes to Songbird receive events.
+- `sink.stop()` stops further buffering; it does not unregister the sink.
+- `async for batch in sink:` yields `pyarrow.RecordBatch` snapshots.
+- `async for pcm in sink[VoiceKey.User(user_id)]:` yields `pyarrow.Int16Array | None`.
+- Consumption is destructive: entries are popped from the queue and cannot be read again.
+- Iteration ends when the queue is empty; it does not wait for new ticks.
+- `max_duration_secs` caps the buffer window and must be greater than zero when set.
+- `drop_oldest` controls whether old ticks are discarded when full.
 
 ## StreamSink Behavior
 
-`StreamSink` pushes ticks through a broadcast channel and is consumed via a stream handle.
+`StreamSink` pushes Arrow `RecordBatch` entries through a broadcast channel.
 
-- **Register**: `vc.listen(sink)` subscribes to `VoiceTick` and `SpeakingStateUpdate` (and disconnect) events.
-- **Stream handle**: `async with sink.stream()` acquires a permit for one consumer.
-- **Concurrency**: `max_concurrent` limits simultaneous stream handles.
-- **Retention**:
-  - `retain=False` drops ticks when no streams are active (default).
-  - `retain=True` keeps ticks in the broadcast buffer (up to `retain_secs`).
-  - Implementation detail: the buffer size is `retain_secs * 50` ticks (20 ms per tick).
-
-### Receive Processing (High-Level)
-
-- `SpeakingStateUpdate` events populate the SSRC → User ID map.
-- On each `VoiceTick`:
-  - Entries with `decoded_voice` become **speaking** PCM data.
-  - Entries without `decoded_voice` are marked **silent** (no PCM stored).
-  - SSRCs in the `silent` list are also marked **silent**.
+- `async with sink.stream()` acquires a permit for one consumer.
+- `max_concurrent` limits simultaneous stream handles and must be greater than zero.
+- `retain_secs` controls broadcast buffer capacity and must be greater than zero.
+- `retain=False` drops ticks when no streams are active.
+- `retain=True` keeps ticks in the broadcast buffer up to `retain_secs`.
 
 ## API Surface (Excerpt)
 
@@ -174,14 +158,20 @@ sink.stop() -> None
 
 vc.listen(sink) -> None  # SongbirdClient
 
-async for tick in sink: ...
+async for batch in sink: ...
 async for pcm in sink[receive.VoiceKey.User(user_id)]: ...
-async with stream_sink.stream() as stream: ...
+async with stream_sink.stream() as stream:
+    async for batch in stream: ...
 ```
 
 ## Limitations & Notes
 
-- **Custom Python sinks are not supported**: `SinkBase` is exposed but cannot be subclassed from Python today.
-- **Distinguish silent vs missing**: use `is_silent()`; `get()` alone cannot tell them apart.
-- **Unbounded buffering**: omit `max_duration_secs` only if you can tolerate growth.
-- **pyarrow dependency**: PCM is returned as `pyarrow.Int16Array`.
+- Custom Python sinks are not supported; `SinkBase` is exposed but cannot be subclassed from Python today.
+- `key_kind` values are stable: `0` is user ID, `1` is unknown SSRC.
+- `VoiceKey.Unknown(ssrc)` is used only while Songbird has not yet observed a
+  `SpeakingStateUpdate` with a user ID for that SSRC. Discord voice state data
+  does not expose SSRCs, so the receive layer does not guess from channel
+  membership.
+- Silent and missing keys are distinct in batch form: silent keys have rows with `speaking=False`; missing keys have no row.
+- Omit `max_duration_secs` only if you can tolerate unbounded buffering.
+- PCM is returned through Arrow and requires the package's Arrow dependencies.

--- a/py-src/discord/ext/songbird/__init__.py
+++ b/py-src/discord/ext/songbird/__init__.py
@@ -7,11 +7,14 @@ from .native import receive as receive
 
 InputBase = player.InputBase
 AudioInput = player.AudioInput
+OpusPacketInput = player.OpusPacketInput
+OpusPacketStreamInput = player.OpusPacketStreamInput
 RawPCMInput = player.RawPCMInput
 StreamInput = player.StreamInput
 Track = player.Track
 TrackHandle = player.TrackHandle
 Queue = player.Queue
+supported_codecs = player.supported_codecs
 
 PySongbirdError = error.PySongbirdError
 PyPlayerError = error.PyPlayerError
@@ -31,8 +34,11 @@ __all__ = (
     "Track",
     "TrackHandle",
     "AudioInput",
+    "OpusPacketInput",
+    "OpusPacketStreamInput",
     "RawPCMInput",
     "StreamInput",
+    "supported_codecs",
     "PySongbirdError",
     "PyPlayerError",
     "PyJoinError",

--- a/py-src/discord/ext/songbird/__init__.pyi
+++ b/py-src/discord/ext/songbird/__init__.pyi
@@ -9,11 +9,14 @@ from .native import receive as receive
 
 InputBase = player.InputBase
 AudioInput = player.AudioInput
+OpusPacketInput = player.OpusPacketInput
+OpusPacketStreamInput = player.OpusPacketStreamInput
 RawPCMInput = player.RawPCMInput
 StreamInput = player.StreamInput
 Track = player.Track
 TrackHandle = player.TrackHandle
 Queue = player.Queue
+supported_codecs = player.supported_codecs
 
 PySongbirdError = error.PySongbirdError
 PyPlayerError = error.PyPlayerError
@@ -30,6 +33,9 @@ __all__ = (
     "Track",
     "TrackHandle",
     "AudioInput",
+    "OpusPacketInput",
+    "OpusPacketStreamInput",
     "RawPCMInput",
     "StreamInput",
+    "supported_codecs",
 )

--- a/py-src/discord/ext/songbird/native/player/__init__.pyi
+++ b/py-src/discord/ext/songbird/native/player/__init__.pyi
@@ -11,11 +11,14 @@ import pyarrow
 __all__ = [
     "AudioInput",
     "InputBase",
+    "OpusPacketInput",
+    "OpusPacketStreamInput",
     "Queue",
     "RawPCMInput",
     "StreamInput",
     "Track",
     "TrackHandle",
+    "supported_codecs",
 ]
 
 @typing.final
@@ -51,6 +54,77 @@ class InputBase:
     """
 
     ...
+
+@typing.final
+class OpusPacketInput(InputBase):
+    r"""
+    Pre-encoded Opus packet input backed by an Arrow binary array.
+
+    Notes
+    -----
+    Each array value must be one non-empty 20 ms Opus frame at 48 kHz.
+    When this input is the only active track and volume is 1.0, Songbird can
+    send these frames through without decoding and re-encoding them.
+    """
+    def __new__(cls, frames: pyarrow.BinaryArray | pyarrow.LargeBinaryArray) -> typing.Self:
+        r"""
+        Create an Opus packet input.
+
+        Parameters
+        ----------
+        frames : pyarrow.BinaryArray | pyarrow.LargeBinaryArray
+            One 20 ms Opus frame per row.
+
+        Returns
+        -------
+        OpusPacketInput
+        """
+
+@typing.final
+class OpusPacketStreamInput(InputBase):
+    r"""
+    Live pre-encoded Opus packet input.
+
+    Notes
+    -----
+    Use ``await send(packet)`` to push one 20 ms Opus frame. The bounded queue
+    provides backpressure and ``close()`` signals EOF to the player.
+    """
+    def __new__(cls, *, max_packets: builtins.int = 128) -> typing.Self:
+        r"""
+        Create a live Opus packet input.
+
+        Parameters
+        ----------
+        max_packets : int, optional
+            Maximum queued packets before ``send`` applies backpressure.
+            Must be greater than zero.
+
+        Returns
+        -------
+        OpusPacketStreamInput
+        """
+    def send(self, packet: bytes) -> typing.Coroutine[typing.Any, typing.Any, None]:
+        r"""
+        Send one 20 ms Opus frame.
+
+        Parameters
+        ----------
+        packet : bytes
+            One non-empty Opus frame containing exactly 960 samples at 48 kHz.
+
+        Returns
+        -------
+        None
+        """
+    def close(self) -> typing.Coroutine[typing.Any, typing.Any, None]:
+        r"""
+        Close the stream and signal EOF to the player.
+
+        Returns
+        -------
+        None
+        """
 
 @typing.final
 class Queue:
@@ -312,3 +386,12 @@ class TrackHandle:
     def enable_loop(self) -> None: ...
     def disable_loop(self) -> None: ...
     def loop_for(self, times: builtins.int) -> None: ...
+
+def supported_codecs() -> builtins.list[builtins.str]:
+    r"""
+    Return codec and format identifiers enabled in this native build.
+
+    Returns
+    -------
+    list[str]
+    """

--- a/py-src/discord/ext/songbird/native/receive/__init__.pyi
+++ b/py-src/discord/ext/songbird/native/receive/__init__.pyi
@@ -9,13 +9,13 @@ connections. The primary entry point is `BufferSink`.
 Classes
 -------
 BufferSink
-    Buffering sink that yields `VoiceTick` snapshots.
+    Buffering sink that yields Arrow `RecordBatch` snapshots.
 StreamSink
-    Streaming sink that yields `VoiceTick` snapshots.
+    Streaming sink that yields Arrow `RecordBatch` snapshots.
 Stream
     Async stream handle returned by `StreamSink.stream()`.
 VoiceTick
-    Per-tick snapshot of speaking and silent sources.
+    Compatibility wrapper for per-tick helpers.
 VoiceKey
     Identifier for a voice source (user ID or SSRC).
 SinkBase
@@ -31,16 +31,15 @@ vc = await channel.connect(cls=songbird.SongbirdClient)
 sink = receive.BufferSink(max_duration_secs=5)
 vc.listen(sink)
 
-async for tick in sink:
-    pcm = tick.get(receive.VoiceKey.User(user_id))
-    if pcm is not None:
-        handle_pcm(pcm)
+async for batch in sink:
+    handle_batch(batch)
 ```
 
 Notes
 -----
-PCM is returned as `pyarrow.Int16Array`. Use `VoiceTick.is_silent()` to
-distinguish silent from missing keys.
+Receive iterators return `pyarrow.RecordBatch` values with `key_kind`,
+`key_id`, `speaking`, and `pcm` columns. Per-key convenience iterators still
+return `pyarrow.Int16Array | None`.
 """
 
 import builtins
@@ -63,7 +62,7 @@ class BufferSink(SinkBase):
     r"""
     Buffering sink for received voice data.
 
-    Collects `VoiceTick` snapshots and exposes them via async iteration.
+    Collects columnar Arrow record batches and exposes them via async iteration.
 
     Examples
     --------
@@ -75,10 +74,8 @@ class BufferSink(SinkBase):
     sink = receive.BufferSink(max_duration_secs=5)
     vc.listen(sink)
 
-    async for tick in sink:
-        pcm = tick.get(receive.VoiceKey.User(user_id))
-        if pcm is not None:
-            handle_pcm(pcm)
+    async for batch in sink:
+        handle_batch(batch)
     ```
     """
     def __new__(
@@ -99,6 +96,7 @@ class BufferSink(SinkBase):
         -----
         Internally converted to a tick count based on 20 ms per tick (50 ticks/sec).
         Parameters are keyword-only.
+        `max_duration_secs=0` is invalid.
 
         Returns
         -------
@@ -138,18 +136,18 @@ class BufferSink(SinkBase):
                 handle_pcm(pcm)
         ```
         """
-    def __aiter__(self) -> model.PyAsyncIterator[VoiceTick]:
+    def __aiter__(self) -> model.PyAsyncIterator[pyarrow.RecordBatch]:
         r"""
-        Return an async iterator over buffered `VoiceTick` entries.
+        Return an async iterator over buffered Arrow record batches.
 
         Returns
         -------
-        PyAsyncIterator[VoiceTick]
+        PyAsyncIterator[pyarrow.RecordBatch]
 
         Examples
         --------
         ```python
-        async for tick in sink:
+        async for batch in sink:
             ...
         ```
         """
@@ -189,13 +187,13 @@ class Stream:
         -------
         Stream
         """
-    def __aiter__(self) -> model.PyAsyncIterator[VoiceTick]:
+    def __aiter__(self) -> model.PyAsyncIterator[pyarrow.RecordBatch]:
         r"""
-        Return an async iterator over `VoiceTick` entries.
+        Return an async iterator over Arrow record batches.
 
         Returns
         -------
-        PyAsyncIterator[VoiceTick]
+        PyAsyncIterator[pyarrow.RecordBatch]
         """
     def __aexit__(
         self, _exc_type: typing.Any, _exc_val: typing.Any, _exc_tb: typing.Any
@@ -236,7 +234,8 @@ class StreamSink(SinkBase):
     Streaming sink for received voice data.
 
     Unlike `BufferSink`, this sink exposes a stream interface backed by a
-    broadcast channel and supports concurrent consumers via permits.
+    broadcast channel and supports concurrent consumers via permits. Stream
+    iteration yields Arrow record batches.
 
     Examples
     --------
@@ -249,7 +248,7 @@ class StreamSink(SinkBase):
     vc.listen(sink)
 
     async with sink.stream() as stream:
-        async for tick in stream:
+        async for batch in stream:
             ...
     ```
     """
@@ -266,8 +265,10 @@ class StreamSink(SinkBase):
         retain_secs : int, optional
             Retention window in seconds for the broadcast buffer.
             Internally converted to a tick count based on 20 ms per tick (50 ticks/sec).
+            Must be greater than zero.
         max_concurrent : int, optional
             Maximum number of concurrent streams.
+            Must be greater than zero.
 
         Returns
         -------
@@ -287,7 +288,7 @@ class StreamSink(SinkBase):
         --------
         ```python
         async with sink.stream() as stream:
-            async for tick in stream:
+            async for batch in stream:
                 ...
         ```
         """
@@ -380,16 +381,12 @@ class VoiceKey:
 @typing.final
 class VoiceTick:
     r"""
-    Snapshot of received voice data for a single tick.
+    Compatibility wrapper for a received voice tick.
 
-    Examples
-    --------
-    ```python
-    key = receive.VoiceKey.User(user_id)
-    pcm = tick.get(key)
-    if pcm is None and tick.is_silent(key):
-        print(\"silent\")
-    ```
+    Notes
+    -----
+    New receive iterators yield `pyarrow.RecordBatch` objects. This class remains
+    available for Rust-side compatibility helpers.
     """
     def get(self, key: VoiceKey) -> typing.Optional[pyarrow.Int16Array]:
         r"""
@@ -404,14 +401,6 @@ class VoiceTick:
         -------
         pyarrow.Int16Array | None
             PCM when speaking, otherwise None.
-
-        Examples
-        --------
-        ```python
-        pcm = tick.get(receive.VoiceKey.User(user_id))
-        if pcm is not None:
-            handle_pcm(pcm)
-        ```
         """
     def is_silent(self, key: VoiceKey) -> builtins.bool:
         r"""
@@ -425,13 +414,6 @@ class VoiceTick:
         Returns
         -------
         bool
-
-        Examples
-        --------
-        ```python
-        if tick.is_silent(receive.VoiceKey.User(user_id)):
-            ...
-        ```
         """
     def all_keys(self) -> builtins.set[VoiceKey]:
         r"""
@@ -440,13 +422,6 @@ class VoiceTick:
         Returns
         -------
         set[VoiceKey]
-
-        Examples
-        --------
-        ```python
-        for key in tick.all_keys():
-            ...
-        ```
         """
     def speaking_keys(self) -> builtins.set[VoiceKey]:
         r"""
@@ -455,13 +430,6 @@ class VoiceTick:
         Returns
         -------
         set[VoiceKey]
-
-        Examples
-        --------
-        ```python
-        for key in tick.speaking_keys():
-            ...
-        ```
         """
     def silent_keys(self) -> builtins.set[VoiceKey]:
         r"""
@@ -470,11 +438,12 @@ class VoiceTick:
         Returns
         -------
         set[VoiceKey]
+        """
+    def record_batch(self) -> pyarrow.RecordBatch:
+        r"""
+        Return this tick as a columnar Arrow record batch.
 
-        Examples
-        --------
-        ```python
-        for key in tick.silent_keys():
-            ...
-        ```
+        Returns
+        -------
+        pyarrow.RecordBatch
         """

--- a/src/client.rs
+++ b/src/client.rs
@@ -5,6 +5,7 @@ use crate::player::queue::PyQueue;
 use crate::player::track::PyTrack;
 use crate::receive::HandlerWrapper;
 use crate::receive::sink::SinkBase;
+use crate::receive::{VoiceIdentityMap, VoiceIdentityTracker};
 use crate::update::VoiceUpdater;
 use pyo3::prelude::PyAnyMethods;
 use pyo3::types::PyTuple;
@@ -17,7 +18,7 @@ use pyo3_stub_gen::derive::{gen_stub_pyclass, gen_stub_pymethods};
 use songbird::driver::{DecodeConfig, DecodeMode};
 use songbird::id::{ChannelId, GuildId, UserId};
 use songbird::shards::Shard;
-use songbird::{Call, Config};
+use songbird::{Call, Config, CoreEvent, Event, EventHandler};
 use std::num::NonZeroU64;
 use std::sync::Arc;
 use std::time::Duration;
@@ -58,6 +59,7 @@ pub struct SongbirdImpl {
     guild_id: GuildId,
     application_id: UserId,
     call: Arc<Mutex<CallWrapper>>,
+    identity_map: Arc<VoiceIdentityMap>,
     current_loop: Option<Py<PyAny>>,
 }
 
@@ -112,6 +114,7 @@ impl SongbirdImpl {
             guild_id: guild_id.into(),
             application_id: application_id.into(),
             call: Arc::new(Mutex::new(CallWrapper::new())),
+            identity_map: Arc::new(VoiceIdentityMap::default()),
             current_loop: Some(current_loop),
         })
     }
@@ -147,6 +150,7 @@ impl SongbirdImpl {
             .gateway_timeout(Some(Duration::from_secs_f32(timeout)))
             .decode_mode(DecodeMode::Decode(DecodeConfig::default()));
         let self_call = slf.call.clone();
+        let identity_map = slf.identity_map.clone();
         let guild_id = slf.guild_id;
         let channel_id = slf.channel_id;
         let application_id = slf.application_id;
@@ -164,7 +168,18 @@ impl SongbirdImpl {
         let shard = Shard::Generic(Arc::new(VoiceUpdater(slf.into_py_any(py)?.into_any())));
 
         future_into_py(py, async move {
-            let call = Call::from_config(guild_id, shard, application_id, config);
+            identity_map.clear();
+            let mut call = Call::from_config(guild_id, shard, application_id, config);
+            let identity_tracker: Arc<dyn EventHandler + Send + Sync> =
+                Arc::new(VoiceIdentityTracker::new(identity_map.clone()));
+            call.add_global_event(
+                Event::Core(CoreEvent::SpeakingStateUpdate),
+                HandlerWrapper(identity_tracker.clone()),
+            );
+            call.add_global_event(
+                Event::Core(CoreEvent::ClientDisconnect),
+                HandlerWrapper(identity_tracker),
+            );
             {
                 let mut guard = self_call.lock().await;
                 guard.set(call);
@@ -213,7 +228,9 @@ impl SongbirdImpl {
         );
         let mut guard = self.call.lock().await;
         let call = guard.get_mut()?;
-        call.leave().await.into_pyerr()
+        call.leave().await.into_pyerr()?;
+        self.identity_map.clear();
+        Ok(())
     }
 
     /// |coro|
@@ -399,6 +416,7 @@ impl SongbirdImpl {
                channel: Option<Bound<'py, PyAny>>,
     ) -> PyResult<PyFuture<'py, ()>> {
         let call = self.call.clone();
+        let identity_map = self.identity_map.clone();
         if let Some(channel) = channel {
             let id = channel.getattr("id")?.extract::<NonZeroU64>()?;
             log::debug!(
@@ -407,6 +425,7 @@ impl SongbirdImpl {
                 id
             );
             future_into_py(py, async move {
+                identity_map.clear();
                 let mut guard = call.lock().await;
                 let call = guard.get_mut()?;
                 call.join(id).await.into_pyerr()?;
@@ -422,6 +441,7 @@ impl SongbirdImpl {
                 let mut guard = call.lock().await;
                 let call = guard.get_mut()?;
                 call.leave().await.into_pyerr()?;
+                identity_map.clear();
                 Ok(())
             })
             .map(|x| x.into())
@@ -453,6 +473,7 @@ impl SongbirdImpl {
     fn listen<'py>(&self, _py: Python<'py>, sink: PyRef<'py, SinkBase>) -> PyResult<()> {
         let mut guard = self.call.blocking_lock();
         let call = guard.get_mut()?;
+        sink.bind_identity(self.identity_map.clone())?;
 
         sink.receive_events.iter().for_each(|event| {
             call.add_global_event(*event, HandlerWrapper(sink.get_subscriber()));

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -74,6 +74,12 @@ VERSION : str
         #[pymodule_export]
         use crate::player::input::audio::PyAudioInput;
         #[pymodule_export]
+        use crate::player::input::opus::PyOpusPacketInput;
+        #[pymodule_export]
+        use crate::player::input::opus::PyOpusPacketStreamInput;
+        #[pymodule_export]
+        use crate::player::input::opus::supported_codecs;
+        #[pymodule_export]
         use crate::player::input::pcm::PyRawPcmInput;
         #[pymodule_export]
         use crate::player::input::stream::PyStreamInput;

--- a/src/model/arrow.rs
+++ b/src/model/arrow.rs
@@ -12,9 +12,17 @@ pub struct ArrowArray<'py, T>(Bound<'py, PyAny>, PhantomData<T>)
 where
     T: ArrayElementType;
 
+pub struct ArrowRecordBatch<'py>(Bound<'py, PyAny>);
+
 impl<'py, T: ArrayElementType> From<Bound<'py, PyAny>> for ArrowArray<'py, T> {
     fn from(value: Bound<'py, PyAny>) -> Self {
         Self(value, PhantomData)
+    }
+}
+
+impl<'py> From<Bound<'py, PyAny>> for ArrowRecordBatch<'py> {
+    fn from(value: Bound<'py, PyAny>) -> Self {
+        Self(value)
     }
 }
 
@@ -34,6 +42,19 @@ where
     }
 }
 
+impl PyStubType for ArrowRecordBatch<'_> {
+    fn type_output() -> TypeInfo {
+        let mut imports = HashSet::new();
+        imports.insert("pyarrow".into());
+        TypeInfo {
+            name: "pyarrow.RecordBatch".into(),
+            source_module: None,
+            import: imports,
+            type_refs: Default::default(),
+        }
+    }
+}
+
 impl<'py, T> IntoPyObject<'py> for ArrowArray<'py, T>
 where
     T: ArrayElementType,
@@ -41,6 +62,16 @@ where
     type Target = PyAny;
     type Output = Bound<'py, Self::Target>;
     type Error = pyo3::PyErr;
+    fn into_pyobject(self, _py: Python<'py>) -> Result<Self::Output, Self::Error> {
+        Ok(self.0)
+    }
+}
+
+impl<'py> IntoPyObject<'py> for ArrowRecordBatch<'py> {
+    type Target = PyAny;
+    type Output = Bound<'py, Self::Target>;
+    type Error = pyo3::PyErr;
+
     fn into_pyobject(self, _py: Python<'py>) -> Result<Self::Output, Self::Error> {
         Ok(self.0)
     }

--- a/src/player/input.rs
+++ b/src/player/input.rs
@@ -1,5 +1,6 @@
 pub(crate) mod audio;
 mod data;
+pub mod opus;
 pub mod pcm;
 pub mod stream;
 

--- a/src/player/input/opus.rs
+++ b/src/player/input/opus.rs
@@ -1,0 +1,761 @@
+use crate::model::PyFuture;
+use crate::player::input::{PyCompose, PyInputBase};
+use arrow::array::{Array, ArrayRef, BinaryArray, LargeBinaryArray};
+use arrow::datatypes::DataType;
+use pyo3::exceptions::{PyRuntimeError, PyTypeError, PyValueError};
+use pyo3::{Bound, PyAny, PyResult, Python, pyclass, pyfunction, pymethods};
+use pyo3_arrow::PyArray;
+use pyo3_async_runtimes::tokio::future_into_py;
+use pyo3_stub_gen::derive::{gen_stub_pyclass, gen_stub_pyfunction, gen_stub_pymethods};
+use songbird::input::core::audio::Layout;
+use songbird::input::core::codecs::{CODEC_TYPE_OPUS, CodecParameters, Decoder, DecoderOptions};
+use songbird::input::core::errors::{
+    self as symph_err, Error as SymphError, Result as SymphResult, SeekErrorKind,
+};
+use songbird::input::core::formats::{
+    Cue, FormatOptions, FormatReader, Packet, SeekMode, SeekTo, SeekedTo, Track,
+};
+use songbird::input::core::io::{MediaSourceStream, MediaSourceStreamOptions};
+use songbird::input::core::meta::{Metadata as SymphMetadata, MetadataLog};
+use songbird::input::core::probe::{
+    Descriptor, Hint, Instantiate, Probe, ProbedMetadata, QueryDescriptor,
+};
+use songbird::input::core::sample::SampleFormat;
+use songbird::input::core::units::TimeBase;
+use songbird::input::{LiveInput, Parsed};
+use std::io::Cursor;
+use std::sync::{Arc, Mutex};
+use tokio::sync::mpsc;
+
+const OPUS_SAMPLE_RATE: u32 = 48_000;
+const OPUS_FRAME_SAMPLES: u64 = 960;
+const OPUS_TRACK_ID: u32 = 0;
+
+type OpusPacket = Box<[u8]>;
+type OpusPacketSender = mpsc::Sender<OpusPacket>;
+type OpusPacketReceiver = mpsc::Receiver<OpusPacket>;
+type SharedSender = Arc<Mutex<Option<OpusPacketSender>>>;
+type SharedReceiver = Arc<Mutex<Option<OpusPacketReceiver>>>;
+
+#[gen_stub_pyclass]
+#[pyclass(
+    name = "OpusPacketInput",
+    extends = PyInputBase,
+    module = "discord.ext.songbird.native.player",
+    skip_from_py_object
+)]
+/// Pre-encoded Opus packet input backed by an Arrow binary array.
+///
+/// Notes
+/// -----
+/// Each array value must be one non-empty 20 ms Opus frame at 48 kHz.
+/// When this input is the only active track and volume is 1.0, Songbird can
+/// send these frames through without decoding and re-encoding them.
+pub struct PyOpusPacketInput {
+    frames: OpusFrameArray,
+}
+
+#[gen_stub_pyclass]
+#[pyclass(
+    name = "OpusPacketStreamInput",
+    extends = PyInputBase,
+    module = "discord.ext.songbird.native.player",
+    skip_from_py_object
+)]
+/// Live pre-encoded Opus packet input.
+///
+/// Notes
+/// -----
+/// Use ``await send(packet)`` to push one 20 ms Opus frame. The bounded queue
+/// provides backpressure and ``close()`` signals EOF to the player.
+pub struct PyOpusPacketStreamInput {
+    sender: SharedSender,
+    receiver: SharedReceiver,
+}
+
+#[derive(Clone)]
+enum OpusFrameArray {
+    Binary(BinaryArray),
+    LargeBinary(LargeBinaryArray),
+}
+
+struct OpusPacketFormatReader {
+    source: OpusPacketSource,
+    track: Vec<Track>,
+    metas: MetadataLog,
+}
+
+enum OpusPacketSource {
+    Batch {
+        frames: OpusFrameArray,
+        index: usize,
+    },
+    Stream {
+        receiver: OpusPacketReceiver,
+        next_ts: u64,
+    },
+}
+
+struct EmptyMetadataReader {
+    source: MediaSourceStream,
+    metas: MetadataLog,
+}
+
+#[gen_stub_pymethods]
+#[pymethods]
+impl PyOpusPacketInput {
+    #[gen_stub(override_return_type(type_repr = "typing.Self", imports = ("typing")))]
+    #[new]
+    /// Create an Opus packet input.
+    ///
+    /// Parameters
+    /// ----------
+    /// frames : pyarrow.BinaryArray | pyarrow.LargeBinaryArray
+    ///     One 20 ms Opus frame per row.
+    ///
+    /// Returns
+    /// -------
+    /// OpusPacketInput
+    fn new(
+        #[gen_stub(override_type(
+            type_repr = "pyarrow.BinaryArray | pyarrow.LargeBinaryArray",
+            imports = ("pyarrow")
+        ))]
+        frames: PyArray,
+    ) -> PyResult<(Self, PyInputBase)> {
+        let frames = OpusFrameArray::try_from_array(frames.array().clone())?;
+        frames.validate()?;
+        Ok((Self { frames }, PyInputBase::new()))
+    }
+
+    #[gen_stub(skip)]
+    fn _compose(&self, _current_loop: Bound<PyAny>) -> PyResult<PyCompose> {
+        let reader = OpusPacketFormatReader::batch(self.frames.clone());
+        let input = parsed_input(reader, true)?;
+        Ok(PyCompose::new_live(input, None))
+    }
+}
+
+#[gen_stub_pymethods]
+#[pymethods]
+impl PyOpusPacketStreamInput {
+    #[gen_stub(override_return_type(type_repr = "typing.Self", imports = ("typing")))]
+    #[new]
+    #[pyo3(signature = (*, max_packets = 128))]
+    /// Create a live Opus packet input.
+    ///
+    /// Parameters
+    /// ----------
+    /// max_packets : int, optional
+    ///     Maximum queued packets before ``send`` applies backpressure.
+    ///     Must be greater than zero.
+    ///
+    /// Returns
+    /// -------
+    /// OpusPacketStreamInput
+    fn new(max_packets: usize) -> PyResult<(Self, PyInputBase)> {
+        if max_packets == 0 {
+            return Err(PyValueError::new_err(
+                "max_packets must be greater than zero",
+            ));
+        }
+        let (sender, receiver) = mpsc::channel(max_packets);
+        Ok((
+            Self {
+                sender: Arc::new(Mutex::new(Some(sender))),
+                receiver: Arc::new(Mutex::new(Some(receiver))),
+            },
+            PyInputBase::new(),
+        ))
+    }
+
+    /// Send one 20 ms Opus frame.
+    ///
+    /// Parameters
+    /// ----------
+    /// packet : bytes
+    ///     One non-empty Opus frame containing exactly 960 samples at 48 kHz.
+    ///
+    /// Returns
+    /// -------
+    /// None
+    fn send<'py>(
+        &self,
+        py: Python<'py>,
+        #[gen_stub(override_type(type_repr = "bytes"))] packet: Vec<u8>,
+    ) -> PyResult<PyFuture<'py, ()>> {
+        validate_opus_frame(&packet)?;
+        let sender = self.sender()?;
+        future_into_py(py, async move {
+            sender
+                .send(packet.into_boxed_slice())
+                .await
+                .map_err(|_| PyRuntimeError::new_err("OpusPacketStreamInput is closed"))?;
+            Ok(())
+        })
+        .map(|x| x.into())
+    }
+
+    /// Close the stream and signal EOF to the player.
+    ///
+    /// Returns
+    /// -------
+    /// None
+    fn close<'py>(&self, py: Python<'py>) -> PyResult<PyFuture<'py, ()>> {
+        let _ = self.take_sender()?;
+        future_into_py(py, async move { Ok(()) }).map(|x| x.into())
+    }
+
+    #[gen_stub(skip)]
+    fn _compose(&self, _current_loop: Bound<PyAny>) -> PyResult<PyCompose> {
+        let receiver = self.take_receiver()?;
+        let reader = OpusPacketFormatReader::stream(receiver);
+        let input = parsed_input(reader, false)?;
+        Ok(PyCompose::new_live(input, None))
+    }
+}
+
+#[gen_stub_pyfunction(module = "discord.ext.songbird.native.player")]
+#[pyfunction]
+/// Return codec and format identifiers enabled in this native build.
+///
+/// Returns
+/// -------
+/// list[str]
+pub fn supported_codecs() -> Vec<&'static str> {
+    let mut values = vec!["opus", "dca", "raw-pcm"];
+
+    if cfg!(any(feature = "codec-full", feature = "codec-aac")) {
+        values.push("aac");
+    }
+    if cfg!(any(feature = "codec-full", feature = "codec-adpcm")) {
+        values.push("adpcm");
+    }
+    if cfg!(any(feature = "codec-full", feature = "codec-alac")) {
+        values.push("alac");
+    }
+    if cfg!(any(feature = "codec-full", feature = "codec-flac")) {
+        values.push("flac");
+    }
+    if cfg!(any(feature = "codec-full", feature = "codec-mp1")) {
+        values.push("mp1");
+    }
+    if cfg!(any(feature = "codec-full", feature = "codec-mp2")) {
+        values.push("mp2");
+    }
+    if cfg!(any(feature = "codec-full", feature = "codec-mp3")) {
+        values.push("mp3");
+    }
+    if cfg!(any(
+        feature = "codec-full",
+        feature = "codec-minimal",
+        feature = "codec-pcm"
+    )) {
+        values.push("pcm");
+    }
+    if cfg!(any(feature = "codec-full", feature = "codec-vorbis")) {
+        values.push("vorbis");
+    }
+    if cfg!(any(feature = "codec-full", feature = "format-aiff")) {
+        values.push("format:aiff");
+    }
+    if cfg!(any(feature = "codec-full", feature = "format-caf")) {
+        values.push("format:caf");
+    }
+    if cfg!(any(feature = "codec-full", feature = "format-isomp4")) {
+        values.push("format:isomp4");
+    }
+    if cfg!(any(feature = "codec-full", feature = "format-mkv")) {
+        values.push("format:mkv");
+    }
+    if cfg!(any(feature = "codec-full", feature = "format-ogg")) {
+        values.push("format:ogg");
+    }
+    if cfg!(any(
+        feature = "codec-full",
+        feature = "codec-minimal",
+        feature = "format-wav"
+    )) {
+        values.push("format:wav");
+    }
+
+    values
+}
+
+impl PyOpusPacketStreamInput {
+    fn sender(&self) -> PyResult<OpusPacketSender> {
+        self.sender
+            .lock()
+            .map_err(|_| PyRuntimeError::new_err("OpusPacketStreamInput lock is poisoned"))?
+            .as_ref()
+            .cloned()
+            .ok_or_else(|| PyRuntimeError::new_err("OpusPacketStreamInput is closed"))
+    }
+
+    fn take_sender(&self) -> PyResult<Option<OpusPacketSender>> {
+        Ok(self
+            .sender
+            .lock()
+            .map_err(|_| PyRuntimeError::new_err("OpusPacketStreamInput lock is poisoned"))?
+            .take())
+    }
+
+    fn take_receiver(&self) -> PyResult<OpusPacketReceiver> {
+        self.receiver
+            .lock()
+            .map_err(|_| PyRuntimeError::new_err("OpusPacketStreamInput lock is poisoned"))?
+            .take()
+            .ok_or_else(|| {
+                PyRuntimeError::new_err("OpusPacketStreamInput has already been composed")
+            })
+    }
+}
+
+impl OpusFrameArray {
+    fn try_from_array(array: ArrayRef) -> PyResult<Self> {
+        match array.data_type() {
+            DataType::Binary => Ok(Self::Binary(
+                array
+                    .as_any()
+                    .downcast_ref::<BinaryArray>()
+                    .expect("DataType::Binary must downcast to BinaryArray")
+                    .clone(),
+            )),
+            DataType::LargeBinary => Ok(Self::LargeBinary(
+                array
+                    .as_any()
+                    .downcast_ref::<LargeBinaryArray>()
+                    .expect("DataType::LargeBinary must downcast to LargeBinaryArray")
+                    .clone(),
+            )),
+            other => Err(PyTypeError::new_err(format!(
+                "Expected a BinaryArray or LargeBinaryArray, got {other}"
+            ))),
+        }
+    }
+
+    fn validate(&self) -> PyResult<()> {
+        if self.null_count() != 0 {
+            return Err(PyValueError::new_err(
+                "Opus packet arrays must not contain nulls",
+            ));
+        }
+        for index in 0..self.len() {
+            validate_opus_frame(self.value(index))?;
+        }
+        Ok(())
+    }
+
+    fn len(&self) -> usize {
+        match self {
+            Self::Binary(array) => array.len(),
+            Self::LargeBinary(array) => array.len(),
+        }
+    }
+
+    fn null_count(&self) -> usize {
+        match self {
+            Self::Binary(array) => array.null_count(),
+            Self::LargeBinary(array) => array.null_count(),
+        }
+    }
+
+    fn value(&self, index: usize) -> &[u8] {
+        match self {
+            Self::Binary(array) => array.value(index),
+            Self::LargeBinary(array) => array.value(index),
+        }
+    }
+
+    #[cfg(test)]
+    fn value_buffer_ptr(&self) -> *const u8 {
+        match self {
+            Self::Binary(array) => array.values().as_ptr(),
+            Self::LargeBinary(array) => array.values().as_ptr(),
+        }
+    }
+}
+
+impl OpusPacketFormatReader {
+    fn batch(frames: OpusFrameArray) -> Self {
+        Self::new(OpusPacketSource::Batch { frames, index: 0 })
+    }
+
+    fn stream(receiver: OpusPacketReceiver) -> Self {
+        Self::new(OpusPacketSource::Stream {
+            receiver,
+            next_ts: 0,
+        })
+    }
+
+    fn new(source: OpusPacketSource) -> Self {
+        Self {
+            source,
+            track: vec![Track::new(OPUS_TRACK_ID, opus_codec_params())],
+            metas: MetadataLog::default(),
+        }
+    }
+}
+
+impl FormatReader for OpusPacketFormatReader {
+    fn try_new(_source: MediaSourceStream, _options: &FormatOptions) -> SymphResult<Self>
+    where
+        Self: Sized,
+    {
+        symph_err::unsupported_error("opus packet inputs are constructed directly")
+    }
+
+    fn cues(&self) -> &[Cue] {
+        &[]
+    }
+
+    fn metadata(&mut self) -> SymphMetadata<'_> {
+        self.metas.metadata()
+    }
+
+    fn seek(&mut self, _mode: SeekMode, to: SeekTo) -> SymphResult<SeekedTo> {
+        let ts = seek_timestamp(&self.track[0], to)?;
+        match &mut self.source {
+            OpusPacketSource::Batch { frames, index } => {
+                let max_ts = (frames.len() as u64) * OPUS_FRAME_SAMPLES;
+                if ts >= max_ts {
+                    return symph_err::seek_error(SeekErrorKind::OutOfRange);
+                }
+                let packet_index = (ts / OPUS_FRAME_SAMPLES) as usize;
+                *index = packet_index;
+                Ok(SeekedTo {
+                    track_id: OPUS_TRACK_ID,
+                    required_ts: ts,
+                    actual_ts: (packet_index as u64) * OPUS_FRAME_SAMPLES,
+                })
+            }
+            OpusPacketSource::Stream { .. } => symph_err::seek_error(SeekErrorKind::Unseekable),
+        }
+    }
+
+    fn tracks(&self) -> &[Track] {
+        &self.track
+    }
+
+    fn default_track(&self) -> Option<&Track> {
+        self.track.first()
+    }
+
+    fn next_packet(&mut self) -> SymphResult<Packet> {
+        match &mut self.source {
+            OpusPacketSource::Batch { frames, index } => {
+                if *index >= frames.len() {
+                    return symph_err::end_of_stream_error();
+                }
+                let ts = (*index as u64) * OPUS_FRAME_SAMPLES;
+                let frame = frames.value(*index);
+                *index += 1;
+                Ok(Packet::new_from_slice(
+                    OPUS_TRACK_ID,
+                    ts,
+                    OPUS_FRAME_SAMPLES,
+                    frame,
+                ))
+            }
+            OpusPacketSource::Stream { receiver, next_ts } => {
+                let Some(frame) = receiver.blocking_recv() else {
+                    return symph_err::end_of_stream_error();
+                };
+                let ts = *next_ts;
+                *next_ts += OPUS_FRAME_SAMPLES;
+                Ok(Packet::new_from_boxed_slice(
+                    OPUS_TRACK_ID,
+                    ts,
+                    OPUS_FRAME_SAMPLES,
+                    frame,
+                ))
+            }
+        }
+    }
+
+    fn into_inner(self: Box<Self>) -> MediaSourceStream {
+        empty_media_source_stream()
+    }
+}
+
+impl QueryDescriptor for EmptyMetadataReader {
+    fn query() -> &'static [Descriptor] {
+        static DESCRIPTORS: &[Descriptor] = &[Descriptor {
+            short_name: "discord-ext-songbird-empty",
+            long_name: "discord-ext-songbird empty metadata probe",
+            extensions: &[],
+            mime_types: &[],
+            markers: &[b"DESB"],
+            score: empty_metadata_score,
+            inst: Instantiate::Format(empty_metadata_instantiate),
+        }];
+        DESCRIPTORS
+    }
+
+    fn score(context: &[u8]) -> u8 {
+        empty_metadata_score(context)
+    }
+}
+
+impl FormatReader for EmptyMetadataReader {
+    fn try_new(source: MediaSourceStream, _options: &FormatOptions) -> SymphResult<Self>
+    where
+        Self: Sized,
+    {
+        Ok(Self {
+            source,
+            metas: MetadataLog::default(),
+        })
+    }
+
+    fn cues(&self) -> &[Cue] {
+        &[]
+    }
+
+    fn metadata(&mut self) -> SymphMetadata<'_> {
+        self.metas.metadata()
+    }
+
+    fn seek(&mut self, _mode: SeekMode, _to: SeekTo) -> SymphResult<SeekedTo> {
+        symph_err::seek_error(SeekErrorKind::Unseekable)
+    }
+
+    fn tracks(&self) -> &[Track] {
+        &[]
+    }
+
+    fn next_packet(&mut self) -> SymphResult<Packet> {
+        symph_err::end_of_stream_error()
+    }
+
+    fn into_inner(self: Box<Self>) -> MediaSourceStream {
+        self.source
+    }
+}
+
+fn validate_opus_frame(frame: &[u8]) -> PyResult<()> {
+    if frame.is_empty() {
+        return Err(PyValueError::new_err("Opus frames must not be empty"));
+    }
+    if frame.len() > i32::MAX as usize {
+        return Err(PyValueError::new_err("Opus frame is too large"));
+    }
+
+    let sample_count = opus2::packet::get_nb_samples(frame, OPUS_SAMPLE_RATE)
+        .map_err(|_| PyValueError::new_err("Opus frame sample count could not be read"))?;
+    if sample_count as u64 != OPUS_FRAME_SAMPLES {
+        return Err(PyValueError::new_err(format!(
+            "Opus frames must contain exactly {OPUS_FRAME_SAMPLES} samples, got {sample_count}"
+        )));
+    }
+    Ok(())
+}
+
+fn parsed_input(reader: OpusPacketFormatReader, supports_backseek: bool) -> PyResult<LiveInput> {
+    let codec_params = reader
+        .default_track()
+        .expect("OpusPacketFormatReader always has one track")
+        .codec_params
+        .clone();
+    let decoder =
+        songbird::input::codecs::OpusDecoder::try_new(&codec_params, &DecoderOptions::default())
+            .map_err(to_py_runtime_error)?;
+    let parsed = Parsed {
+        format: Box::new(reader),
+        decoder: Box::new(decoder),
+        track_id: OPUS_TRACK_ID,
+        meta: empty_probed_metadata()?,
+        supports_backseek,
+    };
+    Ok(LiveInput::Parsed(parsed))
+}
+
+fn opus_codec_params() -> CodecParameters {
+    let mut codec_params = CodecParameters::new();
+    codec_params
+        .for_codec(CODEC_TYPE_OPUS)
+        .with_max_frames_per_packet(1)
+        .with_sample_rate(OPUS_SAMPLE_RATE)
+        .with_time_base(TimeBase::new(1, OPUS_SAMPLE_RATE))
+        .with_sample_format(SampleFormat::F32)
+        .with_channel_layout(Layout::Stereo);
+    codec_params
+}
+
+fn seek_timestamp(track: &Track, to: SeekTo) -> SymphResult<u64> {
+    match to {
+        SeekTo::Time { time, track_id } => {
+            if let Some(track_id) = track_id
+                && track_id != track.id
+            {
+                return symph_err::seek_error(SeekErrorKind::InvalidTrack);
+            }
+            let Some(rate) = track.codec_params.sample_rate else {
+                return symph_err::seek_error(SeekErrorKind::Unseekable);
+            };
+            Ok(TimeBase::new(1, rate).calc_timestamp(time))
+        }
+        SeekTo::TimeStamp { ts, track_id } => {
+            if track_id != track.id {
+                return symph_err::seek_error(SeekErrorKind::InvalidTrack);
+            }
+            Ok(ts)
+        }
+    }
+}
+
+fn empty_probed_metadata() -> PyResult<ProbedMetadata> {
+    let mut probe = Probe::default();
+    probe.register_all::<EmptyMetadataReader>();
+    let source = MediaSourceStream::new(
+        Box::new(Cursor::new(b"DESB".to_vec())),
+        MediaSourceStreamOptions::default(),
+    );
+    probe
+        .format(
+            &Hint::new(),
+            source,
+            &FormatOptions::default(),
+            &songbird::input::core::meta::MetadataOptions::default(),
+        )
+        .map(|result| result.metadata)
+        .map_err(to_py_runtime_error)
+}
+
+fn empty_media_source_stream() -> MediaSourceStream {
+    MediaSourceStream::new(
+        Box::new(Cursor::new(Vec::<u8>::new())),
+        MediaSourceStreamOptions::default(),
+    )
+}
+
+fn empty_metadata_score(_context: &[u8]) -> u8 {
+    255
+}
+
+fn empty_metadata_instantiate(
+    source: MediaSourceStream,
+    options: &FormatOptions,
+) -> SymphResult<Box<dyn FormatReader>> {
+    EmptyMetadataReader::try_new(source, options).map(|reader| Box::new(reader) as _)
+}
+
+fn to_py_runtime_error(err: SymphError) -> pyo3::PyErr {
+    PyRuntimeError::new_err(err.to_string())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use opus2::{Application, Channels, Encoder};
+
+    fn opus_frame_with_samples(samples_per_channel: usize) -> Vec<u8> {
+        let mut encoder =
+            Encoder::new(OPUS_SAMPLE_RATE, Channels::Stereo, Application::Audio).unwrap();
+        let samples = vec![0.0_f32; samples_per_channel * 2];
+        encoder.encode_vec_float(&samples, 4_000).unwrap()
+    }
+
+    fn opus_frame() -> Vec<u8> {
+        opus_frame_with_samples(OPUS_FRAME_SAMPLES as usize)
+    }
+
+    #[test]
+    fn batch_reader_returns_opus_packets_without_payload_clone_on_array_clone() {
+        let first = opus_frame();
+        let second = opus_frame();
+        let array = BinaryArray::from_vec(vec![first.as_slice(), second.as_slice()]);
+        let frames = OpusFrameArray::try_from_array(Arc::new(array)).unwrap();
+        frames.validate().unwrap();
+
+        let clone = frames.clone();
+        assert_eq!(frames.value_buffer_ptr(), clone.value_buffer_ptr());
+
+        let mut reader = OpusPacketFormatReader::batch(clone);
+        assert_eq!(reader.tracks()[0].codec_params.codec, CODEC_TYPE_OPUS);
+
+        let packet = reader.next_packet().unwrap();
+        assert_eq!(packet.track_id(), OPUS_TRACK_ID);
+        assert_eq!(packet.ts(), 0);
+        assert_eq!(packet.dur(), OPUS_FRAME_SAMPLES);
+        assert_eq!(packet.buf(), first.as_slice());
+
+        let packet = reader.next_packet().unwrap();
+        assert_eq!(packet.ts(), OPUS_FRAME_SAMPLES);
+        assert_eq!(packet.dur(), OPUS_FRAME_SAMPLES);
+        assert_eq!(packet.buf(), second.as_slice());
+    }
+
+    #[test]
+    fn batch_reader_seeks_by_timestamp() {
+        let first = opus_frame();
+        let second = opus_frame();
+        let array = LargeBinaryArray::from_vec(vec![first.as_slice(), second.as_slice()]);
+        let frames = OpusFrameArray::try_from_array(Arc::new(array)).unwrap();
+        let mut reader = OpusPacketFormatReader::batch(frames);
+
+        let seeked = reader
+            .seek(
+                SeekMode::Accurate,
+                SeekTo::TimeStamp {
+                    ts: OPUS_FRAME_SAMPLES,
+                    track_id: OPUS_TRACK_ID,
+                },
+            )
+            .unwrap();
+        assert_eq!(seeked.actual_ts, OPUS_FRAME_SAMPLES);
+
+        let packet = reader.next_packet().unwrap();
+        assert_eq!(packet.ts(), OPUS_FRAME_SAMPLES);
+        assert_eq!(packet.buf(), second.as_slice());
+    }
+
+    #[test]
+    fn invalid_packet_arrays_are_rejected() {
+        let frame = opus_frame();
+        let null_array = BinaryArray::from_opt_vec(vec![Some(frame.as_slice()), None]);
+        let frames = OpusFrameArray::try_from_array(Arc::new(null_array)).unwrap();
+        assert!(frames.validate().is_err());
+
+        let empty_array = BinaryArray::from_vec(vec![b"".as_slice()]);
+        let frames = OpusFrameArray::try_from_array(Arc::new(empty_array)).unwrap();
+        assert!(frames.validate().is_err());
+
+        let short_frame = opus_frame_with_samples(480);
+        let short_array = BinaryArray::from_vec(vec![short_frame.as_slice()]);
+        let frames = OpusFrameArray::try_from_array(Arc::new(short_array)).unwrap();
+        assert!(frames.validate().is_err());
+    }
+
+    #[test]
+    fn stream_reader_blocks_until_packet_then_eofs() {
+        let frame = opus_frame();
+        let (sender, receiver) = mpsc::channel(1);
+        sender.try_send(frame.clone().into_boxed_slice()).unwrap();
+        drop(sender);
+
+        let mut reader = OpusPacketFormatReader::stream(receiver);
+        let packet = reader.next_packet().unwrap();
+        assert_eq!(packet.ts(), 0);
+        assert_eq!(packet.dur(), OPUS_FRAME_SAMPLES);
+        assert_eq!(packet.buf(), frame.as_slice());
+        assert!(reader.next_packet().is_err());
+    }
+
+    #[test]
+    fn stream_input_rejects_double_compose() {
+        let (input, _) = PyOpusPacketStreamInput::new(1).unwrap();
+        let _ = input.take_receiver().unwrap();
+        assert!(input.take_receiver().is_err());
+    }
+
+    #[test]
+    fn supported_codecs_reports_default_full_set() {
+        let values = supported_codecs();
+        assert!(values.contains(&"opus"));
+        if cfg!(feature = "codec-full") {
+            assert!(values.contains(&"aac"));
+            assert!(values.contains(&"format:ogg"));
+        }
+    }
+}

--- a/src/receive/identity.rs
+++ b/src/receive/identity.rs
@@ -1,0 +1,138 @@
+use async_trait::async_trait;
+use dashmap::DashMap;
+use songbird::{Event, EventContext, EventHandler};
+use std::sync::{Arc, OnceLock};
+
+#[derive(Debug, Default)]
+pub struct VoiceIdentityMap {
+    ssrc_to_user: DashMap<u32, u64>,
+}
+
+#[derive(Debug, Default)]
+pub struct VoiceIdentityBinding {
+    map: OnceLock<Arc<VoiceIdentityMap>>,
+}
+
+pub trait VoiceIdentityResolver {
+    fn user_id_for_ssrc(&self, ssrc: u32) -> Option<u64>;
+}
+
+pub struct VoiceIdentityTracker {
+    map: Arc<VoiceIdentityMap>,
+}
+
+impl VoiceIdentityMap {
+    pub fn insert(&self, ssrc: u32, user_id: u64) {
+        self.ssrc_to_user.insert(ssrc, user_id);
+    }
+
+    pub fn remove_user(&self, user_id: u64) {
+        self.ssrc_to_user.retain(|_, mapped| *mapped != user_id);
+    }
+
+    pub fn clear(&self) {
+        self.ssrc_to_user.clear();
+    }
+}
+
+impl VoiceIdentityResolver for VoiceIdentityMap {
+    fn user_id_for_ssrc(&self, ssrc: u32) -> Option<u64> {
+        self.ssrc_to_user.get(&ssrc).map(|user_id| *user_id)
+    }
+}
+
+impl VoiceIdentityBinding {
+    pub fn bind(&self, map: Arc<VoiceIdentityMap>) -> Result<(), VoiceIdentityBindError> {
+        if let Some(existing) = self.map.get() {
+            if Arc::ptr_eq(existing, &map) {
+                Ok(())
+            } else {
+                Err(VoiceIdentityBindError::DifferentConnection)
+            }
+        } else {
+            self.map
+                .set(map)
+                .map_err(|_| VoiceIdentityBindError::DifferentConnection)
+        }
+    }
+}
+
+impl VoiceIdentityResolver for VoiceIdentityBinding {
+    fn user_id_for_ssrc(&self, ssrc: u32) -> Option<u64> {
+        self.map.get()?.user_id_for_ssrc(ssrc)
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum VoiceIdentityBindError {
+    DifferentConnection,
+}
+
+impl VoiceIdentityTracker {
+    pub fn new(map: Arc<VoiceIdentityMap>) -> Self {
+        Self { map }
+    }
+}
+
+#[async_trait]
+impl EventHandler for VoiceIdentityTracker {
+    async fn act(&self, ctx: &EventContext<'_>) -> Option<Event> {
+        match ctx {
+            EventContext::SpeakingStateUpdate(speaking) => {
+                if let Some(user_id) = speaking.user_id {
+                    self.map.insert(speaking.ssrc, user_id.0);
+                }
+            }
+            EventContext::ClientDisconnect(disconnect) => {
+                self.map.remove_user(disconnect.user_id.0);
+            }
+            _ => {}
+        }
+        None
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use songbird::model::SpeakingState;
+    use songbird::model::payload::{ClientDisconnect, Speaking};
+    use songbird::{EventContext, model::id::UserId};
+
+    #[tokio::test]
+    async fn tracker_records_speaking_and_disconnect_events() {
+        let map = Arc::new(VoiceIdentityMap::default());
+        let tracker = VoiceIdentityTracker::new(map.clone());
+
+        tracker
+            .act(&EventContext::SpeakingStateUpdate(Speaking {
+                delay: None,
+                speaking: SpeakingState::MICROPHONE,
+                ssrc: 42,
+                user_id: Some(UserId(7)),
+            }))
+            .await;
+        assert_eq!(map.user_id_for_ssrc(42), Some(7));
+
+        tracker
+            .act(&EventContext::ClientDisconnect(ClientDisconnect {
+                user_id: UserId(7),
+            }))
+            .await;
+        assert_eq!(map.user_id_for_ssrc(42), None);
+    }
+
+    #[test]
+    fn binding_rejects_different_connection_maps() {
+        let binding = VoiceIdentityBinding::default();
+        let first = Arc::new(VoiceIdentityMap::default());
+        let second = Arc::new(VoiceIdentityMap::default());
+
+        assert_eq!(binding.bind(first.clone()), Ok(()));
+        assert_eq!(binding.bind(first), Ok(()));
+        assert_eq!(
+            binding.bind(second),
+            Err(VoiceIdentityBindError::DifferentConnection)
+        );
+    }
+}

--- a/src/receive/mod.rs
+++ b/src/receive/mod.rs
@@ -1,8 +1,10 @@
 mod handler;
+mod identity;
 pub mod sink;
 pub(crate) mod tick;
 
 pub use handler::HandlerWrapper;
+pub(crate) use identity::{VoiceIdentityMap, VoiceIdentityTracker};
 
 pyo3_stub_gen::module_doc!(
     "discord.ext.songbird.native.receive",
@@ -15,13 +17,13 @@ connections. The primary entry point is `BufferSink`.
 Classes
 -------
 BufferSink
-    Buffering sink that yields `VoiceTick` snapshots.
+    Buffering sink that yields Arrow `RecordBatch` snapshots.
 StreamSink
-    Streaming sink that yields `VoiceTick` snapshots.
+    Streaming sink that yields Arrow `RecordBatch` snapshots.
 Stream
     Async stream handle returned by `StreamSink.stream()`.
 VoiceTick
-    Per-tick snapshot of speaking and silent sources.
+    Compatibility wrapper for per-tick helpers.
 VoiceKey
     Identifier for a voice source (user ID or SSRC).
 SinkBase
@@ -37,15 +39,14 @@ vc = await channel.connect(cls=songbird.SongbirdClient)
 sink = receive.BufferSink(max_duration_secs=5)
 vc.listen(sink)
 
-async for tick in sink:
-    pcm = tick.get(receive.VoiceKey.User(user_id))
-    if pcm is not None:
-        handle_pcm(pcm)
+async for batch in sink:
+    handle_batch(batch)
 ```
 
 Notes
 -----
-PCM is returned as `pyarrow.Int16Array`. Use `VoiceTick.is_silent()` to
-distinguish silent from missing keys.
+Receive iterators return `pyarrow.RecordBatch` values with `key_kind`,
+`key_id`, `speaking`, and `pcm` columns. Per-key convenience iterators still
+return `pyarrow.Int16Array | None`.
 "#,
 );

--- a/src/receive/sink.rs
+++ b/src/receive/sink.rs
@@ -1,6 +1,8 @@
 mod buffer;
 mod stream;
 
+use super::identity::{VoiceIdentityBindError, VoiceIdentityBinding, VoiceIdentityMap};
+use pyo3::exceptions::PyRuntimeError;
 use pyo3::{PyResult, pyclass};
 use pyo3_stub_gen::derive::gen_stub_pyclass;
 use songbird::{Event, EventHandler};
@@ -24,21 +26,67 @@ pub use stream::{PyStream, StreamSink};
 /// Custom sinks are not currently supported from Python.
 pub struct SinkBase {
     subscriber: Arc<dyn EventHandler + Send + Sync>,
+    identity: Arc<VoiceIdentityBinding>,
     pub receive_events: HashSet<Event>,
 }
 
 impl SinkBase {
     fn new(
         subscriber: Arc<dyn EventHandler + Send + Sync>,
+        identity: Arc<VoiceIdentityBinding>,
         receive_events: HashSet<Event>,
     ) -> PyResult<Self> {
         Ok(Self {
             subscriber,
+            identity,
             receive_events,
         })
     }
 
     pub fn get_subscriber(&self) -> Arc<dyn EventHandler + Send + Sync> {
         self.subscriber.clone()
+    }
+
+    pub fn bind_identity(&self, map: Arc<VoiceIdentityMap>) -> PyResult<()> {
+        self.identity.bind(map).map_err(|err| match err {
+            VoiceIdentityBindError::DifferentConnection => {
+                PyRuntimeError::new_err("receive sinks cannot be reused across voice connections")
+            }
+        })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use async_trait::async_trait;
+    use songbird::{CoreEvent, EventContext};
+
+    struct NoopHandler;
+
+    #[async_trait]
+    impl EventHandler for NoopHandler {
+        async fn act(&self, _ctx: &EventContext<'_>) -> Option<Event> {
+            None
+        }
+    }
+
+    #[test]
+    fn sink_rejects_binding_to_different_voice_connection() {
+        let identity = Arc::new(VoiceIdentityBinding::default());
+        let sink = SinkBase::new(
+            Arc::new(NoopHandler),
+            identity,
+            vec![Event::Core(CoreEvent::VoiceTick)]
+                .into_iter()
+                .collect(),
+        )
+        .expect("sink construction should succeed");
+        let first = Arc::new(VoiceIdentityMap::default());
+        let second = Arc::new(VoiceIdentityMap::default());
+
+        assert!(sink.bind_identity(first.clone()).is_ok());
+        assert!(sink.bind_identity(first).is_ok());
+        assert!(sink.bind_identity(second).is_err());
     }
 }

--- a/src/receive/sink/buffer.rs
+++ b/src/receive/sink/buffer.rs
@@ -195,18 +195,16 @@ impl BufferSink {
         let ticks = self.ticks.clone();
         let s = stream! {
             loop {
-                let tick = {
+                let Some(tick) = ({
                     let mut guard = ticks.lock().await;
-                    if let Some(tick) = guard.pop_front() {
-                        Python::attach(|py| {
-                            let k = tick.get(py, &key);
-                            k.and_then(|x| x.into_py_any(py))
-                        })
-                    } else {
-                        drop(guard);
-                        break;
-                    }
+                    guard.pop_front()
+                }) else {
+                    break;
                 };
+                let tick = Python::attach(|py| {
+                    let k = tick.get(py, &key);
+                    k.and_then(|x| x.into_py_any(py))
+                });
                 yield tick;
             }
         };
@@ -231,17 +229,15 @@ impl BufferSink {
         let ticks = slf.ticks.clone();
         let s = stream! {
             loop {
-                let tick = {
+                let Some(tick) = ({
                     let mut guard = ticks.lock().await;
-                    if let Some(tick) = guard.pop_front() {
-                        Python::attach(|py| {
-                            tick.to_record_batch(py).and_then(|x| x.into_py_any(py))
-                        })
-                    } else {
-                        drop(guard);
-                        break;
-                    }
+                    guard.pop_front()
+                }) else {
+                    break;
                 };
+                let tick = Python::attach(|py| {
+                    tick.to_record_batch(py).and_then(|x| x.into_py_any(py))
+                });
                 yield tick;
             }
         };

--- a/src/receive/sink/buffer.rs
+++ b/src/receive/sink/buffer.rs
@@ -1,10 +1,11 @@
-use crate::model::{ArrowArray, Generic, PyAsyncIterator};
+use crate::model::{ArrowArray, ArrowRecordBatch, Generic, PyAsyncIterator};
+use crate::receive::identity::VoiceIdentityBinding;
 use crate::receive::sink::SinkBase;
-use crate::receive::tick::{VoiceKey, VoiceTick};
+use crate::receive::tick::{VoiceKey, VoiceTickBatch};
 use arrow::array::Int16Array;
 use async_stream::stream;
 use async_trait::async_trait;
-use dashmap::DashMap;
+use pyo3::exceptions::PyValueError;
 use pyo3::{IntoPyObjectExt, PyRef, PyResult, Python, pyclass, pymethods};
 use pyo3_stub_gen::derive::{gen_stub_pyclass, gen_stub_pymethods};
 use songbird::{CoreEvent, Event, EventContext, EventHandler};
@@ -15,8 +16,8 @@ use tokio::sync::Mutex;
 
 pub struct BufferSinkHandler {
     is_stopped: Arc<AtomicBool>,
-    ssrc_map: DashMap<u32, u64>,
-    ticks: Arc<Mutex<VecDeque<VoiceTick>>>,
+    identity: Arc<VoiceIdentityBinding>,
+    ticks: Arc<Mutex<VecDeque<Arc<VoiceTickBatch>>>>,
     max_ticks: Option<usize>,
     drop_oldest: bool,
 }
@@ -29,7 +30,7 @@ pub struct BufferSinkHandler {
 )]
 /// Buffering sink for received voice data.
 ///
-/// Collects `VoiceTick` snapshots and exposes them via async iteration.
+/// Collects columnar Arrow record batches and exposes them via async iteration.
 ///
 /// Examples
 /// --------
@@ -41,26 +42,25 @@ pub struct BufferSinkHandler {
 /// sink = receive.BufferSink(max_duration_secs=5)
 /// vc.listen(sink)
 ///
-/// async for tick in sink:
-///     pcm = tick.get(receive.VoiceKey.User(user_id))
-///     if pcm is not None:
-///         handle_pcm(pcm)
+/// async for batch in sink:
+///     handle_batch(batch)
 /// ```
 pub struct BufferSink {
     is_stopped: Arc<AtomicBool>,
-    ticks: Arc<Mutex<VecDeque<VoiceTick>>>,
+    ticks: Arc<Mutex<VecDeque<Arc<VoiceTickBatch>>>>,
 }
 
 impl BufferSinkHandler {
     pub fn new(
-        ticks: Arc<Mutex<VecDeque<VoiceTick>>>,
+        ticks: Arc<Mutex<VecDeque<Arc<VoiceTickBatch>>>>,
         is_stopped: Arc<AtomicBool>,
+        identity: Arc<VoiceIdentityBinding>,
         max_ticks: Option<usize>,
         drop_oldest: bool,
     ) -> Self {
         Self {
             is_stopped,
-            ssrc_map: DashMap::new(),
+            identity,
             ticks,
             max_ticks,
             drop_oldest,
@@ -74,30 +74,19 @@ impl EventHandler for BufferSinkHandler {
         if self.is_stopped.load(Ordering::Relaxed) {
             return None;
         }
-        match ctx {
-            EventContext::SpeakingStateUpdate(speaking) => {
-                if let Some(user_id) = speaking.user_id {
-                    self.ssrc_map.insert(speaking.ssrc, user_id.0);
-                }
-            }
-            EventContext::VoiceTick(tick) => {
-                let mut guard = self.ticks.lock().await;
-                if let Some(max_ticks) = self.max_ticks {
-                    if self.drop_oldest {
-                        while guard.len() >= max_ticks {
-                            guard.pop_front();
-                        }
-                    } else if guard.len() >= max_ticks {
-                        return None;
+        if let EventContext::VoiceTick(tick) = ctx {
+            let mut guard = self.ticks.lock().await;
+            if let Some(max_ticks) = self.max_ticks {
+                if self.drop_oldest {
+                    while guard.len() >= max_ticks {
+                        guard.pop_front();
                     }
+                } else if guard.len() >= max_ticks {
+                    return None;
                 }
-                let tick = VoiceTick::from_parts(tick, &self.ssrc_map);
-                guard.push_back(tick);
             }
-            EventContext::ClientDisconnect(disconnect) => {
-                self.ssrc_map.retain(|_, v| !disconnect.user_id.0.eq(v));
-            }
-            _ => {}
+            let tick = VoiceTickBatch::from_parts(tick, &*self.identity);
+            guard.push_back(tick);
         }
         None
     }
@@ -123,31 +112,46 @@ impl BufferSink {
     /// -----
     /// Internally converted to a tick count based on 20 ms per tick (50 ticks/sec).
     /// Parameters are keyword-only.
+    /// `max_duration_secs=0` is invalid.
     ///
     /// Returns
     /// -------
     /// BufferSink
     fn new(max_duration_secs: Option<usize>, drop_oldest: bool) -> PyResult<(Self, SinkBase)> {
         let is_stopped = Arc::new(AtomicBool::new(false));
-        let max_ticks = max_duration_secs.map(|secs| secs * 50);
+        let max_ticks = match max_duration_secs {
+            Some(0) => {
+                return Err(PyValueError::new_err(
+                    "max_duration_secs must be greater than zero",
+                ));
+            }
+            Some(secs) => Some(
+                secs.checked_mul(50)
+                    .ok_or_else(|| PyValueError::new_err("max_duration_secs is too large"))?,
+            ),
+            None => None,
+        };
+        let identity = Arc::new(VoiceIdentityBinding::default());
         let ticks = Arc::new(Mutex::new(if let Some(max) = max_ticks {
             VecDeque::with_capacity(max)
         } else {
             VecDeque::new()
         }));
-        let handler =
-            BufferSinkHandler::new(ticks.clone(), is_stopped.clone(), max_ticks, drop_oldest);
+        let handler = BufferSinkHandler::new(
+            ticks.clone(),
+            is_stopped.clone(),
+            identity.clone(),
+            max_ticks,
+            drop_oldest,
+        );
         Ok((
             Self { is_stopped, ticks },
             SinkBase::new(
                 Arc::new(handler),
-                vec![
-                    Event::Core(CoreEvent::VoiceTick),
-                    Event::Core(CoreEvent::SpeakingStateUpdate),
-                    Event::Core(CoreEvent::ClientDisconnect),
-                ]
-                .into_iter()
-                .collect(),
+                identity,
+                vec![Event::Core(CoreEvent::VoiceTick)]
+                    .into_iter()
+                    .collect(),
             )?,
         ))
     }
@@ -209,26 +213,30 @@ impl BufferSink {
         Ok(Generic::new(PyAsyncIterator::new_in_raw(s)))
     }
 
-    /// Return an async iterator over buffered `VoiceTick` entries.
+    /// Return an async iterator over buffered Arrow record batches.
     ///
     /// Returns
     /// -------
-    /// PyAsyncIterator[VoiceTick]
+    /// PyAsyncIterator[pyarrow.RecordBatch]
     ///
     /// Examples
     /// --------
     /// ```python
-    /// async for tick in sink:
+    /// async for batch in sink:
     ///     ...
     /// ```
-    fn __aiter__<'py>(slf: PyRef<'py, Self>) -> Generic<'py, PyAsyncIterator, VoiceTick> {
+    fn __aiter__<'py>(
+        slf: PyRef<'py, Self>,
+    ) -> Generic<'py, PyAsyncIterator, ArrowRecordBatch<'py>> {
         let ticks = slf.ticks.clone();
         let s = stream! {
             loop {
                 let tick = {
                     let mut guard = ticks.lock().await;
                     if let Some(tick) = guard.pop_front() {
-                        tick
+                        Python::attach(|py| {
+                            tick.to_record_batch(py).and_then(|x| x.into_py_any(py))
+                        })
                     } else {
                         drop(guard);
                         break;
@@ -237,6 +245,6 @@ impl BufferSink {
                 yield tick;
             }
         };
-        Generic::new(PyAsyncIterator::new(s))
+        Generic::new(PyAsyncIterator::new_in_raw(s))
     }
 }

--- a/src/receive/sink/stream.rs
+++ b/src/receive/sink/stream.rs
@@ -1,10 +1,11 @@
-use crate::model::{ArrowArray, Generic, PyAsyncIterator, PyFuture};
+use crate::model::{ArrowArray, ArrowRecordBatch, Generic, PyAsyncIterator, PyFuture};
+use crate::receive::identity::VoiceIdentityBinding;
 use crate::receive::sink::SinkBase;
-use crate::receive::tick::{VoiceKey, VoiceTick};
+use crate::receive::tick::{VoiceKey, VoiceTickBatch};
 use arrow::array::Int16Array;
 use async_trait::async_trait;
-use dashmap::DashMap;
 use futures::StreamExt;
+use pyo3::exceptions::PyValueError;
 use pyo3::{Bound, IntoPyObjectExt, PyAny, PyRef, PyRefMut, PyResult, Python, pyclass, pymethods};
 use pyo3_async_runtimes::tokio::future_into_py;
 use pyo3_stub_gen::derive::{gen_stub_pyclass, gen_stub_pymethods};
@@ -22,7 +23,8 @@ use tokio_stream::wrappers::BroadcastStream;
 /// Streaming sink for received voice data.
 ///
 /// Unlike `BufferSink`, this sink exposes a stream interface backed by a
-/// broadcast channel and supports concurrent consumers via permits.
+/// broadcast channel and supports concurrent consumers via permits. Stream
+/// iteration yields Arrow record batches.
 ///
 /// Examples
 /// --------
@@ -35,13 +37,12 @@ use tokio_stream::wrappers::BroadcastStream;
 /// vc.listen(sink)
 ///
 /// async with sink.stream() as stream:
-///     async for tick in stream:
+///     async for batch in stream:
 ///         ...
 /// ```
-#[allow(unused)]
 pub struct StreamSink {
-    rx: broadcast::Receiver<Option<VoiceTick>>,
-    weak_tx: broadcast::WeakSender<Option<VoiceTick>>,
+    _rx: broadcast::Receiver<Arc<VoiceTickBatch>>,
+    weak_tx: broadcast::WeakSender<Arc<VoiceTickBatch>>,
     sem: Arc<Semaphore>,
 }
 
@@ -57,36 +58,26 @@ pub struct StreamSink {
 pub struct PyStream {
     acquire: Option<OwnedSemaphorePermit>,
     sem: Arc<Semaphore>,
-    weak_tx: broadcast::WeakSender<Option<VoiceTick>>,
+    weak_tx: broadcast::WeakSender<Arc<VoiceTickBatch>>,
 }
 
 pub struct StreamSinkHandler {
-    tx: broadcast::Sender<Option<VoiceTick>>,
+    tx: broadcast::Sender<Arc<VoiceTickBatch>>,
     max_concurrent: usize,
     retain: bool,
     sem: Arc<Semaphore>,
-    ssrc_map: DashMap<u32, u64>,
+    identity: Arc<VoiceIdentityBinding>,
 }
 
 #[async_trait]
 impl EventHandler for StreamSinkHandler {
     async fn act(&self, ctx: &EventContext<'_>) -> Option<Event> {
         match ctx {
-            EventContext::SpeakingStateUpdate(speaking) => {
-                if let Some(user_id) = speaking.user_id {
-                    self.ssrc_map.insert(speaking.ssrc, user_id.0);
-                }
-            }
-            EventContext::VoiceTick(tick) => {
-                if self.sem.available_permits() < self.max_concurrent || self.retain {
-                    let tick = VoiceTick::from_parts(tick, &self.ssrc_map);
-                    drop(self.tx.send(Some(tick)))
-                } else {
-                    drop(self.tx.send(None))
-                }
-            }
-            EventContext::ClientDisconnect(disconnect) => {
-                self.ssrc_map.retain(|_, v| !disconnect.user_id.0.eq(v));
+            EventContext::VoiceTick(tick)
+                if self.sem.available_permits() < self.max_concurrent || self.retain =>
+            {
+                let tick = VoiceTickBatch::from_parts(tick, &*self.identity);
+                drop(self.tx.send(tick))
             }
             _ => {}
         }
@@ -109,18 +100,38 @@ impl StreamSink {
     /// retain_secs : int, optional
     ///     Retention window in seconds for the broadcast buffer.
     ///     Internally converted to a tick count based on 20 ms per tick (50 ticks/sec).
+    ///     Must be greater than zero.
     /// max_concurrent : int, optional
     ///     Maximum number of concurrent streams.
+    ///     Must be greater than zero.
     ///
     /// Returns
     /// -------
     /// StreamSink
-    fn new(retain: bool, retain_secs: usize, max_concurrent: usize) -> (StreamSink, SinkBase) {
-        let (tx, rx) = broadcast::channel(retain_secs * 50);
+    fn new(
+        retain: bool,
+        retain_secs: usize,
+        max_concurrent: usize,
+    ) -> PyResult<(StreamSink, SinkBase)> {
+        if retain_secs == 0 {
+            return Err(PyValueError::new_err(
+                "retain_secs must be greater than zero",
+            ));
+        }
+        if max_concurrent == 0 {
+            return Err(PyValueError::new_err(
+                "max_concurrent must be greater than zero",
+            ));
+        }
+        let retain_ticks = retain_secs
+            .checked_mul(50)
+            .ok_or_else(|| PyValueError::new_err("retain_secs is too large"))?;
+        let (tx, rx) = broadcast::channel(retain_ticks);
         let sem = Arc::new(Semaphore::new(max_concurrent));
-        (
+        let identity = Arc::new(VoiceIdentityBinding::default());
+        Ok((
             StreamSink {
-                rx,
+                _rx: rx,
                 sem: sem.clone(),
                 weak_tx: tx.downgrade(),
             },
@@ -130,17 +141,14 @@ impl StreamSink {
                     max_concurrent,
                     retain,
                     sem,
-                    ssrc_map: Default::default(),
+                    identity: identity.clone(),
                 }),
-                receive_events: vec![
-                    Event::Core(CoreEvent::VoiceTick),
-                    Event::Core(CoreEvent::SpeakingStateUpdate),
-                    Event::Core(CoreEvent::ClientDisconnect),
-                ]
-                .into_iter()
-                .collect(),
+                identity,
+                receive_events: vec![Event::Core(CoreEvent::VoiceTick)]
+                    .into_iter()
+                    .collect(),
             },
-        )
+        ))
     }
 
     /// Create an async stream handle.
@@ -155,7 +163,7 @@ impl StreamSink {
     /// --------
     /// ```python
     /// async with sink.stream() as stream:
-    ///     async for tick in stream:
+    ///     async for batch in stream:
     ///         ...
     /// ```
     fn stream(&self) -> PyResult<PyStream> {
@@ -203,17 +211,21 @@ impl PyStream {
         fut.map(|x| x.into())
     }
 
-    /// Return an async iterator over `VoiceTick` entries.
+    /// Return an async iterator over Arrow record batches.
     ///
     /// Returns
     /// -------
-    /// PyAsyncIterator[VoiceTick]
-    fn __aiter__<'py>(slf: PyRef<'py, Self>) -> PyResult<Generic<'py, PyAsyncIterator, VoiceTick>> {
+    /// PyAsyncIterator[pyarrow.RecordBatch]
+    fn __aiter__<'py>(
+        slf: PyRef<'py, Self>,
+    ) -> PyResult<Generic<'py, PyAsyncIterator, ArrowRecordBatch<'py>>> {
         let tx = slf.try_tx()?;
         let rx = tx.subscribe();
-        let stream = BroadcastStream::new(rx).filter_map(|r| async move { r.ok().flatten() });
+        let stream = BroadcastStream::new(rx)
+            .filter_map(|r| async move { r.ok() })
+            .map(|r| Python::attach(|py| r.to_record_batch(py).and_then(|x| x.into_py_any(py))));
 
-        Ok(Generic::new(PyAsyncIterator::new(stream)))
+        Ok(Generic::new(PyAsyncIterator::new_in_raw(stream)))
     }
 
     /// Exit the async context and release the stream permit.
@@ -257,7 +269,7 @@ impl PyStream {
         let tx = self.try_tx()?;
         let rx = tx.subscribe();
         let stream = BroadcastStream::new(rx)
-            .filter_map(|r| async move { r.ok().flatten() })
+            .filter_map(|r| async move { r.ok() })
             .map(move |r| {
                 Python::attach(|py| {
                     let k = r.get(py, &key);
@@ -270,7 +282,7 @@ impl PyStream {
 }
 
 impl PyStream {
-    fn try_tx(&self) -> PyResult<broadcast::Sender<Option<VoiceTick>>> {
+    fn try_tx(&self) -> PyResult<broadcast::Sender<Arc<VoiceTickBatch>>> {
         if self.acquire.is_none() {
             return Err(pyo3::exceptions::PyRuntimeError::new_err(
                 "StreamSink has been closed",

--- a/src/receive/tick.rs
+++ b/src/receive/tick.rs
@@ -1,13 +1,20 @@
-use crate::model::ArrowArray;
-use arrow::array::Int16Array;
-use dashmap::DashMap;
+use crate::model::{ArrowArray, ArrowRecordBatch};
+use crate::receive::identity::VoiceIdentityResolver;
+use arrow::array::{
+    ArrayRef, BooleanArray, Int16Array, Int16Builder, ListArray, ListBuilder, RecordBatch,
+    UInt8Array, UInt64Array,
+};
+use arrow::datatypes::{DataType, Field, Schema, SchemaRef};
 use pyo3::types::PyInt;
 use pyo3::{Bound, PyResult, Python, pyclass, pymethods};
-use pyo3_arrow::PyArray;
+use pyo3_arrow::{PyArray, PyRecordBatch};
 use pyo3_stub_gen::derive::{gen_stub_pyclass, gen_stub_pyclass_complex_enum, gen_stub_pymethods};
 use songbird::events::context_data::VoiceTick as SongbirdVoiceTick;
 use std::collections::HashSet;
-use std::sync::Arc;
+use std::sync::{Arc, OnceLock};
+
+const KEY_KIND_USER: u8 = 0;
+const KEY_KIND_UNKNOWN_SSRC: u8 = 1;
 
 #[gen_stub_pyclass_complex_enum]
 #[pyclass(module = "discord.ext.songbird.native.receive", frozen, from_py_object)]
@@ -28,26 +35,35 @@ pub enum VoiceKey {
     Unknown(u32),
 }
 
+#[derive(Clone)]
+pub struct VoiceTickBatch {
+    batch: RecordBatch,
+    key_kind: UInt8Array,
+    key_id: UInt64Array,
+    speaking: BooleanArray,
+    pcm: ListArray,
+}
+
+struct VoiceTickRow<'a> {
+    key: VoiceKey,
+    pcm: Option<&'a [i16]>,
+}
+
 #[gen_stub_pyclass]
 #[pyclass(
     module = "discord.ext.songbird.native.receive",
     frozen,
     skip_from_py_object
 )]
-/// Snapshot of received voice data for a single tick.
+/// Compatibility wrapper for a received voice tick.
 ///
-/// Examples
-/// --------
-/// ```python
-/// key = receive.VoiceKey.User(user_id)
-/// pcm = tick.get(key)
-/// if pcm is None and tick.is_silent(key):
-///     print(\"silent\")
-/// ```
-#[derive(Default, Clone)]
+/// Notes
+/// -----
+/// New receive iterators yield `pyarrow.RecordBatch` objects. This class remains
+/// available for Rust-side compatibility helpers.
+#[derive(Clone)]
 pub struct VoiceTick {
-    pub speaking: DashMap<VoiceKey, Arc<Int16Array>>,
-    pub silent: HashSet<VoiceKey>,
+    inner: Arc<VoiceTickBatch>,
 }
 
 #[gen_stub_pymethods]
@@ -131,26 +147,12 @@ impl VoiceTick {
     /// -------
     /// pyarrow.Int16Array | None
     ///     PCM when speaking, otherwise None.
-    ///
-    /// Examples
-    /// --------
-    /// ```python
-    /// pcm = tick.get(receive.VoiceKey.User(user_id))
-    /// if pcm is not None:
-    ///     handle_pcm(pcm)
-    /// ```
     pub fn get<'py>(
         &self,
         py: Python<'py>,
         key: &VoiceKey,
     ) -> PyResult<Option<ArrowArray<'py, Int16Array>>> {
-        if let Some(data) = self.speaking.get(key) {
-            Ok(Some(
-                PyArray::from_array_ref(data.clone()).into_arro3(py)?.into(),
-            ))
-        } else {
-            Ok(None)
-        }
+        self.inner.get(py, key)
     }
 
     /// Check whether a key is marked silent in this tick.
@@ -163,15 +165,8 @@ impl VoiceTick {
     /// Returns
     /// -------
     /// bool
-    ///
-    /// Examples
-    /// --------
-    /// ```python
-    /// if tick.is_silent(receive.VoiceKey.User(user_id)):
-    ///     ...
-    /// ```
     pub fn is_silent(&self, key: &VoiceKey) -> bool {
-        self.silent.contains(key)
+        self.inner.is_silent(key)
     }
 
     /// Return all keys present in this tick (speaking + silent).
@@ -179,21 +174,8 @@ impl VoiceTick {
     /// Returns
     /// -------
     /// set[VoiceKey]
-    ///
-    /// Examples
-    /// --------
-    /// ```python
-    /// for key in tick.all_keys():
-    ///     ...
-    /// ```
     fn all_keys(&self) -> HashSet<VoiceKey> {
-        let mut all_keys: HashSet<VoiceKey> = self
-            .speaking
-            .iter()
-            .map(|entry| entry.key().clone())
-            .collect();
-        all_keys.extend(self.silent.iter().cloned());
-        all_keys
+        self.inner.all_keys()
     }
 
     /// Return keys that have PCM data in this tick.
@@ -201,18 +183,8 @@ impl VoiceTick {
     /// Returns
     /// -------
     /// set[VoiceKey]
-    ///
-    /// Examples
-    /// --------
-    /// ```python
-    /// for key in tick.speaking_keys():
-    ///     ...
-    /// ```
     fn speaking_keys(&self) -> HashSet<VoiceKey> {
-        self.speaking
-            .iter()
-            .map(|entry| entry.key().clone())
-            .collect()
+        self.inner.speaking_keys()
     }
 
     /// Return keys marked silent in this tick.
@@ -220,47 +192,354 @@ impl VoiceTick {
     /// Returns
     /// -------
     /// set[VoiceKey]
-    ///
-    /// Examples
-    /// --------
-    /// ```python
-    /// for key in tick.silent_keys():
-    ///     ...
-    /// ```
     fn silent_keys(&self) -> HashSet<VoiceKey> {
-        self.silent.clone()
+        self.inner.silent_keys()
+    }
+
+    /// Return this tick as a columnar Arrow record batch.
+    ///
+    /// Returns
+    /// -------
+    /// pyarrow.RecordBatch
+    fn record_batch<'py>(&self, py: Python<'py>) -> PyResult<ArrowRecordBatch<'py>> {
+        self.inner.to_record_batch(py)
     }
 }
 
 impl VoiceTick {
-    pub fn from_parts(tick: &SongbirdVoiceTick, ssrc_data: &DashMap<u32, u64>) -> Self {
-        let mut silents = tick
-            .silent
-            .iter()
-            .map(|ssrc| {
-                if let Some(user_id) = ssrc_data.get(ssrc) {
-                    VoiceKey::User(*user_id)
-                } else {
-                    VoiceKey::Unknown(*ssrc)
-                }
-            })
-            .collect::<HashSet<_>>();
-        let payloads = DashMap::with_capacity(tick.speaking.len());
-        for (ssrc, data) in &tick.speaking {
-            let key = if let Some(user_id) = ssrc_data.get(ssrc) {
-                VoiceKey::User(*user_id)
+    pub fn from_batch(inner: Arc<VoiceTickBatch>) -> Self {
+        Self { inner }
+    }
+}
+
+impl VoiceTickBatch {
+    pub fn from_parts(
+        tick: &SongbirdVoiceTick,
+        identities: &impl VoiceIdentityResolver,
+    ) -> Arc<Self> {
+        Self::from_ssrc_rows(
+            tick.speaking
+                .iter()
+                .map(|(ssrc, data)| (*ssrc, data.decoded_voice.as_deref())),
+            tick.silent.iter().copied(),
+            identities,
+        )
+    }
+
+    fn from_ssrc_rows<'a, S, I>(
+        speaking: S,
+        silent: I,
+        identities: &impl VoiceIdentityResolver,
+    ) -> Arc<Self>
+    where
+        S: IntoIterator<Item = (u32, Option<&'a [i16]>)>,
+        I: IntoIterator<Item = u32>,
+    {
+        let speaking = speaking.into_iter();
+        let silent = silent.into_iter();
+        let speaking_capacity = speaking.size_hint().0;
+        let silent_capacity = silent.size_hint().0;
+        let mut rows = Vec::with_capacity(speaking_capacity + silent_capacity);
+        let mut speaking_keys = HashSet::with_capacity(speaking_capacity);
+
+        for (ssrc, decoded) in speaking {
+            let key = key_for_ssrc(ssrc, identities);
+            if let Some(decoded) = decoded {
+                speaking_keys.insert(key.clone());
+                rows.push(VoiceTickRow {
+                    key,
+                    pcm: Some(decoded),
+                });
             } else {
-                VoiceKey::Unknown(*ssrc)
-            };
-            if let Some(decoded) = &data.decoded_voice {
-                payloads.insert(key, Arc::new(Int16Array::from(decoded.clone())));
-            } else {
-                silents.insert(key);
+                rows.push(VoiceTickRow { key, pcm: None });
             }
         }
-        VoiceTick {
-            speaking: payloads,
-            silent: silents,
+
+        for ssrc in silent {
+            let key = key_for_ssrc(ssrc, identities);
+            if !speaking_keys.contains(&key) {
+                rows.push(VoiceTickRow { key, pcm: None });
+            }
         }
+
+        Arc::new(Self::from_rows(rows))
+    }
+
+    fn from_rows(mut rows: Vec<VoiceTickRow<'_>>) -> Self {
+        rows.sort_by_key(|row| (key_kind(&row.key), key_id(&row.key)));
+
+        let total_samples = rows
+            .iter()
+            .filter_map(|row| row.pcm)
+            .map(<[i16]>::len)
+            .sum();
+
+        let key_kind = UInt8Array::from(
+            rows.iter()
+                .map(|row| key_kind(&row.key))
+                .collect::<Vec<_>>(),
+        );
+        let key_id = UInt64Array::from(rows.iter().map(|row| key_id(&row.key)).collect::<Vec<_>>());
+        let speaking =
+            BooleanArray::from(rows.iter().map(|row| row.pcm.is_some()).collect::<Vec<_>>());
+
+        let values = Int16Builder::with_capacity(total_samples);
+        let item_field = Arc::new(Field::new_list_field(DataType::Int16, false));
+        let mut pcm_builder = ListBuilder::with_capacity(values, rows.len()).with_field(item_field);
+        for row in &rows {
+            if let Some(pcm) = row.pcm {
+                pcm_builder.values().append_slice(pcm);
+            }
+            pcm_builder.append(true);
+        }
+        let pcm = pcm_builder.finish();
+
+        let batch = RecordBatch::try_new(
+            voice_tick_schema(),
+            vec![
+                Arc::new(key_kind.clone()) as ArrayRef,
+                Arc::new(key_id.clone()) as ArrayRef,
+                Arc::new(speaking.clone()) as ArrayRef,
+                Arc::new(pcm.clone()) as ArrayRef,
+            ],
+        )
+        .expect("VoiceTickBatch columns must match the fixed schema");
+
+        Self {
+            batch,
+            key_kind,
+            key_id,
+            speaking,
+            pcm,
+        }
+    }
+
+    pub fn record_batch(&self) -> RecordBatch {
+        self.batch.clone()
+    }
+
+    pub fn to_record_batch<'py>(&self, py: Python<'py>) -> PyResult<ArrowRecordBatch<'py>> {
+        PyRecordBatch::new(self.record_batch())
+            .into_arro3(py)
+            .map(Into::into)
+    }
+
+    pub fn get<'py>(
+        &self,
+        py: Python<'py>,
+        key: &VoiceKey,
+    ) -> PyResult<Option<ArrowArray<'py, Int16Array>>> {
+        if let Some(data) = self.get_array_ref(key) {
+            Ok(Some(PyArray::from_array_ref(data).into_arro3(py)?.into()))
+        } else {
+            Ok(None)
+        }
+    }
+
+    pub fn get_array_ref(&self, key: &VoiceKey) -> Option<ArrayRef> {
+        self.find_row(key)
+            .filter(|row| self.speaking.value(*row))
+            .map(|row| self.pcm.value(row))
+    }
+
+    pub fn is_silent(&self, key: &VoiceKey) -> bool {
+        self.find_row(key)
+            .is_some_and(|row| !self.speaking.value(row))
+    }
+
+    fn all_keys(&self) -> HashSet<VoiceKey> {
+        (0..self.batch.num_rows())
+            .map(|row| self.key_at(row))
+            .collect()
+    }
+
+    fn speaking_keys(&self) -> HashSet<VoiceKey> {
+        (0..self.batch.num_rows())
+            .filter(|row| self.speaking.value(*row))
+            .map(|row| self.key_at(row))
+            .collect()
+    }
+
+    fn silent_keys(&self) -> HashSet<VoiceKey> {
+        (0..self.batch.num_rows())
+            .filter(|row| !self.speaking.value(*row))
+            .map(|row| self.key_at(row))
+            .collect()
+    }
+
+    fn find_row(&self, key: &VoiceKey) -> Option<usize> {
+        let kind = key_kind(key);
+        let id = key_id(key);
+        (0..self.batch.num_rows())
+            .find(|row| self.key_kind.value(*row) == kind && self.key_id.value(*row) == id)
+    }
+
+    fn key_at(&self, row: usize) -> VoiceKey {
+        match self.key_kind.value(row) {
+            KEY_KIND_USER => VoiceKey::User(self.key_id.value(row)),
+            KEY_KIND_UNKNOWN_SSRC => VoiceKey::Unknown(
+                self.key_id
+                    .value(row)
+                    .try_into()
+                    .expect("unknown SSRC keys are stored as u32-compatible values"),
+            ),
+            _ => unreachable!("VoiceTickBatch only stores fixed key kinds"),
+        }
+    }
+}
+
+fn voice_tick_schema() -> SchemaRef {
+    static SCHEMA: OnceLock<SchemaRef> = OnceLock::new();
+    SCHEMA
+        .get_or_init(|| {
+            Arc::new(Schema::new(vec![
+                Field::new("key_kind", DataType::UInt8, false),
+                Field::new("key_id", DataType::UInt64, false),
+                Field::new("speaking", DataType::Boolean, false),
+                Field::new_list("pcm", Field::new_list_field(DataType::Int16, false), false),
+            ]))
+        })
+        .clone()
+}
+
+fn key_for_ssrc(ssrc: u32, identities: &impl VoiceIdentityResolver) -> VoiceKey {
+    if let Some(user_id) = identities.user_id_for_ssrc(ssrc) {
+        VoiceKey::User(user_id)
+    } else {
+        VoiceKey::Unknown(ssrc)
+    }
+}
+
+fn key_kind(key: &VoiceKey) -> u8 {
+    match key {
+        VoiceKey::User(_) => KEY_KIND_USER,
+        VoiceKey::Unknown(_) => KEY_KIND_UNKNOWN_SSRC,
+    }
+}
+
+fn key_id(key: &VoiceKey) -> u64 {
+    match key {
+        VoiceKey::User(user_id) => *user_id,
+        VoiceKey::Unknown(ssrc) => u64::from(*ssrc),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use arrow::array::AsArray;
+    use arrow::datatypes::Int16Type;
+
+    fn int16_values(array: &ArrayRef) -> Vec<i16> {
+        array
+            .as_primitive::<Int16Type>()
+            .values()
+            .iter()
+            .copied()
+            .collect()
+    }
+
+    #[test]
+    fn builds_expected_columnar_batch() {
+        let user_pcm = [1, 2, 3, 4];
+        let unknown_pcm = [9, 8];
+        let batch = VoiceTickBatch::from_rows(vec![
+            VoiceTickRow {
+                key: VoiceKey::Unknown(42),
+                pcm: Some(&unknown_pcm),
+            },
+            VoiceTickRow {
+                key: VoiceKey::User(7),
+                pcm: Some(&user_pcm),
+            },
+            VoiceTickRow {
+                key: VoiceKey::User(9),
+                pcm: None,
+            },
+        ]);
+
+        assert_eq!(
+            batch
+                .record_batch()
+                .schema()
+                .fields()
+                .iter()
+                .map(|field| field.name().as_str())
+                .collect::<Vec<_>>(),
+            ["key_kind", "key_id", "speaking", "pcm"]
+        );
+        assert_eq!(
+            batch.key_kind.values(),
+            &[KEY_KIND_USER, KEY_KIND_USER, KEY_KIND_UNKNOWN_SSRC]
+        );
+        assert_eq!(batch.key_id.values(), &[7, 9, 42]);
+        assert!(batch.speaking.value(0));
+        assert!(!batch.speaking.value(1));
+        assert!(batch.speaking.value(2));
+        assert_eq!(batch.pcm.value_offsets(), &[0, 4, 4, 6]);
+        assert_eq!(int16_values(batch.pcm.values()), vec![1, 2, 3, 4, 9, 8]);
+    }
+
+    #[test]
+    fn per_key_helper_returns_zero_copy_pcm_slice() {
+        let user_pcm = [1, 2, 3, 4];
+        let unknown_pcm = [9, 8];
+        let batch = VoiceTickBatch::from_rows(vec![
+            VoiceTickRow {
+                key: VoiceKey::User(7),
+                pcm: Some(&user_pcm),
+            },
+            VoiceTickRow {
+                key: VoiceKey::Unknown(42),
+                pcm: Some(&unknown_pcm),
+            },
+        ]);
+
+        let base = batch.pcm.values().as_primitive::<Int16Type>();
+        let base_ptr = base.values().inner().as_ptr();
+        let user = batch
+            .get_array_ref(&VoiceKey::User(7))
+            .expect("user PCM should be present");
+        let user = user.as_primitive::<Int16Type>();
+        let unknown = batch
+            .get_array_ref(&VoiceKey::Unknown(42))
+            .expect("unknown PCM should be present");
+        let unknown = unknown.as_primitive::<Int16Type>();
+
+        assert_eq!(user.values(), &[1, 2, 3, 4]);
+        assert_eq!(unknown.values(), &[9, 8]);
+        assert_eq!(user.values().inner().as_ptr(), base_ptr);
+        assert_eq!(
+            unknown.values().inner().as_ptr(),
+            base_ptr.wrapping_add(user_pcm.len() * std::mem::size_of::<i16>())
+        );
+    }
+
+    #[test]
+    fn clone_keeps_payload_buffer_shared() {
+        let pcm = [1, 2, 3, 4];
+        let batch = VoiceTickBatch::from_rows(vec![VoiceTickRow {
+            key: VoiceKey::User(7),
+            pcm: Some(&pcm),
+        }]);
+        let cloned = batch.clone();
+
+        let original_values = batch.pcm.values().as_primitive::<Int16Type>();
+        let cloned_values = cloned.pcm.values().as_primitive::<Int16Type>();
+        assert_eq!(
+            original_values.values().inner().as_ptr(),
+            cloned_values.values().inner().as_ptr()
+        );
+    }
+
+    #[test]
+    fn ssrc_rows_resolve_user_ids_from_shared_identity_map() {
+        let identities = crate::receive::identity::VoiceIdentityMap::default();
+        identities.insert(42, 7);
+        let pcm = [1, 2, 3, 4];
+        let batch = VoiceTickBatch::from_ssrc_rows([(42, Some(pcm.as_slice()))], [99], &identities);
+
+        assert_eq!(batch.speaking_keys(), HashSet::from([VoiceKey::User(7)]));
+        assert_eq!(batch.silent_keys(), HashSet::from([VoiceKey::Unknown(99)]));
     }
 }

--- a/src/receive/tick.rs
+++ b/src/receive/tick.rs
@@ -10,7 +10,7 @@ use pyo3::{Bound, PyResult, Python, pyclass, pymethods};
 use pyo3_arrow::{PyArray, PyRecordBatch};
 use pyo3_stub_gen::derive::{gen_stub_pyclass, gen_stub_pyclass_complex_enum, gen_stub_pymethods};
 use songbird::events::context_data::VoiceTick as SongbirdVoiceTick;
-use std::collections::HashSet;
+use std::collections::{HashMap, HashSet};
 use std::sync::{Arc, OnceLock};
 
 const KEY_KIND_USER: u8 = 0;
@@ -239,28 +239,29 @@ impl VoiceTickBatch {
         let silent = silent.into_iter();
         let speaking_capacity = speaking.size_hint().0;
         let silent_capacity = silent.size_hint().0;
-        let mut rows = Vec::with_capacity(speaking_capacity + silent_capacity);
-        let mut speaking_keys = HashSet::with_capacity(speaking_capacity);
+        let mut rows_by_key = HashMap::with_capacity(speaking_capacity + silent_capacity);
 
         for (ssrc, decoded) in speaking {
             let key = key_for_ssrc(ssrc, identities);
             if let Some(decoded) = decoded {
-                speaking_keys.insert(key.clone());
-                rows.push(VoiceTickRow {
-                    key,
-                    pcm: Some(decoded),
-                });
+                let entry = rows_by_key.entry(key).or_insert(None);
+                if entry.is_none() {
+                    *entry = Some(decoded);
+                }
             } else {
-                rows.push(VoiceTickRow { key, pcm: None });
+                rows_by_key.entry(key).or_insert(None);
             }
         }
 
         for ssrc in silent {
             let key = key_for_ssrc(ssrc, identities);
-            if !speaking_keys.contains(&key) {
-                rows.push(VoiceTickRow { key, pcm: None });
-            }
+            rows_by_key.entry(key).or_insert(None);
         }
+
+        let rows = rows_by_key
+            .into_iter()
+            .map(|(key, pcm)| VoiceTickRow { key, pcm })
+            .collect();
 
         Arc::new(Self::from_rows(rows))
     }
@@ -541,5 +542,45 @@ mod tests {
 
         assert_eq!(batch.speaking_keys(), HashSet::from([VoiceKey::User(7)]));
         assert_eq!(batch.silent_keys(), HashSet::from([VoiceKey::Unknown(99)]));
+    }
+
+    #[test]
+    fn ssrc_rows_merge_duplicate_user_keys_and_prefer_pcm() {
+        let identities = crate::receive::identity::VoiceIdentityMap::default();
+        identities.insert(42, 7);
+        identities.insert(43, 7);
+        identities.insert(44, 7);
+        let first_pcm = [1, 2, 3, 4];
+        let second_pcm = [9, 8];
+        let batch = VoiceTickBatch::from_ssrc_rows(
+            [
+                (42, None),
+                (43, Some(first_pcm.as_slice())),
+                (44, Some(second_pcm.as_slice())),
+            ],
+            [42],
+            &identities,
+        );
+
+        assert_eq!(batch.record_batch().num_rows(), 1);
+        assert_eq!(batch.speaking_keys(), HashSet::from([VoiceKey::User(7)]));
+        assert_eq!(batch.silent_keys(), HashSet::new());
+        let pcm = batch
+            .get_array_ref(&VoiceKey::User(7))
+            .expect("merged user PCM should be present");
+        assert_eq!(int16_values(&pcm), first_pcm);
+    }
+
+    #[test]
+    fn ssrc_rows_merge_duplicate_silent_user_keys() {
+        let identities = crate::receive::identity::VoiceIdentityMap::default();
+        identities.insert(42, 7);
+        identities.insert(43, 7);
+        let batch = VoiceTickBatch::from_ssrc_rows([(42, None)], [42, 43], &identities);
+
+        assert_eq!(batch.record_batch().num_rows(), 1);
+        assert_eq!(batch.all_keys(), HashSet::from([VoiceKey::User(7)]));
+        assert_eq!(batch.speaking_keys(), HashSet::new());
+        assert_eq!(batch.silent_keys(), HashSet::from([VoiceKey::User(7)]));
     }
 }


### PR DESCRIPTION
## Summary
- Refactor receive ticks into Arrow RecordBatch-centered state with shared PCM buffers and connection-level SSRC identity tracking.
- Add `OpusPacketInput` and `OpusPacketStreamInput` for pre-encoded 20 ms Opus packet passthrough paths.
- Switch published wheels to the full Symphonia codec/format set by default, while keeping source-build feature switches such as `codec-minimal`.
- Update README, generated stubs, release smoke checks, and Rust tests.

## Validation
- `cargo run --bin stub_gen`
- `cargo fmt`
- `cargo test`
- `PYO3_PYTHON="$PWD/.venv/bin/python" cargo clippy`
- `uv run --no-sync ruff check`
- `uv run --no-sync ty check`
- `PYO3_PYTHON="$PWD/.venv/bin/python" cargo clippy --all-features --all-targets`
- `PYO3_PYTHON="$PWD/.venv/bin/python" cargo check --no-default-features --features codec-minimal`
- `PYO3_PYTHON="$PWD/.venv/bin/python" .venv/bin/maturin develop`
- Python smoke for existing inputs, Opus packet inputs, and `supported_codecs()`
- `git diff --check`

## Notes
- `gh auth status` reports an invalid local token, so the PR was created via the GitHub connector after pushing with Git over SSH.
- `uv run` and `maturin develop` needed normal host permissions because sandboxed access to `~/.cache/uv` failed.