### PR TITLE
[codex] Bump version to 0.5.0 and add send docs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -955,7 +955,7 @@ dependencies = [
 
 [[package]]
 name = "discord-ext-songbird"
-version = "0.4.3"
+version = "0.5.0"
 dependencies = [
  "arrow",
  "async-stream",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 name = "discord-ext-songbird"
 description = "Library to replace the voice backend of discord.py with Songbird."
 readme = "README.md"
-version = "0.4.3"
+version = "0.5.0"
 edition = "2024"
 license = "MIT"
 repository = "https://github.com/sizumita/discord-ext-songbird"

--- a/README.md
+++ b/README.md
@@ -55,6 +55,9 @@ client.run(DISCORD_BOT_TOKEN)
 
 ## Features
 
+Detailed API guides are available for [voice output](docs/send.md) and
+[voice receive](docs/receive.md).
+
 ### Playback
 
 Use `SongbirdClient` as your voice client. Playback is driven by `Track` and `TrackHandle`.
@@ -137,6 +140,9 @@ See `examples/` for runnable bots:
 - `examples/basic.py` (PCM playback)
 - `examples/send_stream.py` (stream input)
 - `examples/receive_stream.py` (voice receive)
+
+For deeper usage notes, see [Send (Voice Output)](docs/send.md) and
+[Receive (Voice Input)](docs/receive.md).
 
 Set `DISCORD_BOT_TOKEN` and `CHANNEL_ID` before running the examples.
 

--- a/docs/send.md
+++ b/docs/send.md
@@ -1,0 +1,241 @@
+# Send (Voice Output)
+
+This document describes the voice send API in `discord-ext-songbird`.
+The public Python surface is re-exported from `discord.ext.songbird.player`,
+which is backed by the native module `discord.ext.songbird.native.player`.
+
+## Overview
+
+- Voice output is done by connecting with `SongbirdClient` and playing `Track` values.
+- Tracks are created from native input types such as `RawPCMInput`, `AudioInput`, and `StreamInput`.
+- `SongbirdClient.play()` starts a track immediately and returns a `TrackHandle`.
+- `SongbirdClient.enqueue()` adds a track to the call queue and returns a `TrackHandle`.
+- Playback can be controlled through `TrackHandle` and the call `Queue`.
+
+## Quick Start
+
+```python
+import discord
+import pyarrow as pa
+from discord.ext import songbird
+from discord.ext.songbird import player
+
+# ... obtain a voice channel and connect
+vc = await channel.connect(cls=songbird.SongbirdClient)
+
+samples = pa.array([0.0, 0.1, 0.0, -0.1], type=pa.float32())
+source = player.RawPCMInput(samples, sample_rate=48000, channels=2)
+track = player.Track(source).volume(0.8)
+
+handle = await vc.play(track)
+handle.pause()
+handle.play()
+```
+
+For queued playback:
+
+```python
+track = player.Track(source).pause()
+handle = await vc.enqueue(track)
+
+# The track was queued as paused. Start it when ready.
+handle.play()
+```
+
+## Input Types
+
+Native input types are exported from `discord.ext.songbird.player`.
+
+| input | source | intended use |
+| --- | --- | --- |
+| `RawPCMInput` | `pyarrow.Float32Array` | In-memory interleaved float32 PCM |
+| `AudioInput` | `pyarrow.Array` | In-memory encoded audio payload |
+| `StreamInput` | `asyncio.StreamReader` | Live or long-running encoded streams |
+| `OpusPacketInput` | `pyarrow.BinaryArray` or `pyarrow.LargeBinaryArray` | In-memory 20 ms Opus frames |
+| `OpusPacketStreamInput` | `await send(packet)` | Live 20 ms Opus packet streams |
+
+`AudioInput` and `StreamInput` do not take a codec argument. Songbird and
+Symphonia detect supported encoded formats from the payload or stream.
+
+Use `player.supported_codecs()` to inspect the codecs and formats enabled in
+the native build.
+
+## Raw PCM
+
+`RawPCMInput` accepts interleaved float32 PCM samples. The defaults are
+48 kHz stereo, which matches Discord voice output.
+
+```python
+import pyarrow as pa
+from discord.ext.songbird import player
+
+samples = pa.array([0.0, 0.1, 0.0, -0.1], type=pa.float32())
+source = player.RawPCMInput(samples, sample_rate=48000, channels=2)
+track = player.Track(source)
+await vc.play(track)
+```
+
+## Encoded Audio Arrays
+
+`AudioInput` accepts an encoded audio payload stored in a primitive Arrow
+array. The payload format is detected by Songbird/Symphonia.
+
+```python
+import pyarrow as pa
+from discord.ext.songbird import player
+
+payload = pa.array(encoded_bytes, type=pa.uint8())
+source = player.AudioInput(payload)
+await vc.enqueue(player.Track(source))
+```
+
+## Stream Input
+
+`StreamInput` wraps an `asyncio.StreamReader`. The player reads from the stream
+as the track is consumed, so this is the preferred API for radio streams,
+network responses, and other live encoded sources.
+
+```python
+import asyncio
+from discord.ext.songbird import player
+
+buffer = asyncio.StreamReader()
+source = player.StreamInput(buffer)
+handle = await vc.enqueue(player.Track(source))
+
+handle.play()
+```
+
+Feed bytes with `buffer.feed_data(chunk)` and signal end of input with
+`buffer.feed_eof()` when the stream is complete.
+
+## Opus Packet Input
+
+`OpusPacketInput` and `OpusPacketStreamInput` are for pre-encoded Opus. Each
+packet must be one non-empty 20 ms Opus frame containing 960 samples at 48 kHz.
+
+For finite packets:
+
+```python
+import pyarrow as pa
+from discord.ext.songbird import player
+
+frames = pa.array([opus_frame_0, opus_frame_1], type=pa.binary())
+source = player.OpusPacketInput(frames)
+await vc.play(player.Track(source))
+```
+
+For live packets:
+
+```python
+from discord.ext.songbird import player
+
+source = player.OpusPacketStreamInput(max_packets=128)
+handle = await vc.play(player.Track(source))
+
+await source.send(opus_frame)
+await source.close()
+```
+
+When an Opus packet input is the only active track and volume is `1.0`,
+Songbird can send frames without decoding and re-encoding them. Do not change
+volume if you need passthrough behavior.
+
+## Track And Playback Control
+
+`Track` is a builder for playback configuration. Its mutating methods return
+the same track object so calls can be chained before playback starts.
+
+```python
+track = player.Track(source).volume(0.5).pause()
+handle = await vc.enqueue(track)
+handle.play()
+```
+
+Common control methods:
+
+- `Track.play()` marks the initial track state as playing.
+- `Track.pause()` marks the initial track state as paused.
+- `Track.stop()` marks the initial track state as stopped.
+- `Track.volume(value)` sets the initial volume multiplier.
+- `TrackHandle.play()` resumes playback.
+- `TrackHandle.pause()` pauses playback.
+- `TrackHandle.stop()` stops playback.
+- `TrackHandle.seek(position)` seeks when the underlying source supports it.
+- `TrackHandle.enable_loop()`, `disable_loop()`, and `loop_for(times)` control looping.
+
+## Queue Behavior
+
+Use `SongbirdClient.queue()` to inspect or control the active call queue.
+
+```python
+queue = vc.queue()
+
+current = queue.current()
+queued = queue.tracks()
+
+queue.pause()
+queue.resume()
+queue.skip()
+queue.stop()
+```
+
+Key points:
+
+- `await vc.play(track)` starts a track immediately through Songbird's call handle.
+- `await vc.enqueue(track)` appends a track to the playback queue.
+- `vc.stop()` stops playback immediately.
+- `queue.current()` returns the current `TrackHandle`, if any.
+- `queue.dequeue(index)` removes a queued track by zero-based index.
+- `len(queue)` returns the queue length and `queue[index]` returns a handle or `None`.
+
+## Data Flow
+
+```text
+Python input source
+        |
+        v
+  player.InputBase
+        |
+        v
+  player.Track
+        |
+        v
+SongbirdClient.play/enqueue
+        |
+        v
+ Songbird call / queue
+        |
+        v
+ Discord voice output
+```
+
+## API Surface (Excerpt)
+
+```python
+from discord.ext.songbird import player
+
+source = player.RawPCMInput(samples, sample_rate=48000, channels=2)
+source = player.AudioInput(payload)
+source = player.StreamInput(stream_reader)
+source = player.OpusPacketInput(frames)
+source = player.OpusPacketStreamInput(max_packets=128)
+
+track = player.Track(source).volume(1.0).play()
+
+handle = await vc.play(track)
+handle = await vc.enqueue(track)
+
+vc.stop() -> None
+queue = vc.queue()
+```
+
+## Limitations & Notes
+
+- Custom Python input subclasses are not supported; use the native input types.
+- Live and streaming inputs are consumed as playback reads them; create a fresh input and track for replay.
+- `StreamInput` expects `read()` to return bytes-like data; non-bytes values are rejected.
+- Call `feed_eof()` on `asyncio.StreamReader` sources when no more data will arrive.
+- `OpusPacketStreamInput.close()` signals EOF to the player and prevents further sends.
+- Opus packet arrays must not contain nulls.
+- Published wheels are built with the full Symphonia codec/format set enabled.

--- a/py-src/discord/ext/songbird/native/__init__.pyi
+++ b/py-src/discord/ext/songbird/native/__init__.pyi
@@ -38,7 +38,7 @@ __all__ = [
     "receive",
 ]
 
-VERSION: builtins.str = "0.4.3"
+VERSION: builtins.str = "0.5.0"
 
 class SongbirdImpl:
     r"""


### PR DESCRIPTION
## Summary

- Bump the package version from `0.4.3` to `0.5.0`.
- Regenerate the native Python stub so `VERSION` matches the Cargo package version.
- Add `docs/send.md` covering voice output, input types, playback controls, queue behavior, and Opus passthrough notes.
- Link the send/receive guides from `README.md`.

## Validation

- `PYO3_PYTHON="$PWD/.venv/bin/python" cargo run --bin stub_gen`
- `PYO3_PYTHON="$PWD/.venv/bin/python" cargo clippy`
- `uv run --no-sync ruff check`
- `uv run --no-sync ty check`
- `cargo fmt --check`
- `git diff --check`
- `cargo build`
- `PYO3_PYTHON="$PWD/.venv/bin/python" cargo build`
- `cargo build --all-features`
- `cargo build --locked`
