### PR TITLE
[codex] Fix release CI wheel jobs

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,10 +18,6 @@ jobs:
             target: x86_64
           - runner: ubuntu-22.04
             target: aarch64
-          - runner: ubuntu-22.04
-            target: s390x
-          - runner: ubuntu-22.04
-            target: ppc64le
         python-version:
           - 3.14
           - 3.14t
@@ -71,7 +67,7 @@ jobs:
       - name: Smoke test native wheel
         if: matrix.platform.target == 'x86_64'
         run: |
-          uv run --no-sync python -m pip install --force-reinstall dist/*.whl
+          uv pip install --reinstall dist/*.whl
           if [[ "${{ matrix.python-version }}" == *t ]]; then export PYTHON_GIL=0; fi
           uv run --no-sync python -c "import asyncio, pyarrow as pa; asyncio.set_event_loop(asyncio.new_event_loop()); from discord.ext import songbird; from discord.ext.songbird import player; assert not hasattr(songbird, 'SupportedCodec'); player.AudioInput(pa.array([1, 2, 3], type=pa.uint8())); player.RawPCMInput(pa.array([0.0, 0.0], type=pa.float32()), sample_rate=48000, channels=2); player.StreamInput(asyncio.StreamReader()); player.OpusPacketInput(pa.array([b'\xf8\xff\xfe'], type=pa.binary())); player.OpusPacketStreamInput(max_packets=1); assert 'opus' in player.supported_codecs()"
 
@@ -198,7 +194,7 @@ jobs:
         if: matrix.platform.target == 'x64'
         shell: bash
         run: |
-          uv run --no-sync python -m pip install --force-reinstall dist/*.whl
+          uv pip install --reinstall dist/*.whl
           if [[ "${{ matrix.python-version }}" == *t ]]; then export PYTHON_GIL=0; fi
           uv run --no-sync python -c "import asyncio, pyarrow as pa; asyncio.set_event_loop(asyncio.new_event_loop()); from discord.ext import songbird; from discord.ext.songbird import player; assert not hasattr(songbird, 'SupportedCodec'); player.AudioInput(pa.array([1, 2, 3], type=pa.uint8())); player.RawPCMInput(pa.array([0.0, 0.0], type=pa.float32()), sample_rate=48000, channels=2); player.StreamInput(asyncio.StreamReader()); player.OpusPacketInput(pa.array([b'\xf8\xff\xfe'], type=pa.binary())); player.OpusPacketStreamInput(max_packets=1); assert 'opus' in player.supported_codecs()"
       - name: Upload wheels
@@ -270,13 +266,15 @@ jobs:
 
       - name: Build wheels
         uses: PyO3/maturin-action@v1
+        env:
+          PIP_BREAK_SYSTEM_PACKAGES: "1"
         with:
           target: ${{ matrix.platform.target }}
           args: --release --out dist -i ${{ matrix.python-version }} --features pyo3/generate-import-lib
-          sccache: 'true'
+          sccache: 'false'
       - name: Smoke test native wheel
         run: |
-          uv run --no-sync python -m pip install --force-reinstall dist/*.whl
+          uv pip install --reinstall dist/*.whl
           if [[ "${{ matrix.python-version }}" == *t ]]; then export PYTHON_GIL=0; fi
           uv run --no-sync python -c "import asyncio, pyarrow as pa; asyncio.set_event_loop(asyncio.new_event_loop()); from discord.ext import songbird; from discord.ext.songbird import player; assert not hasattr(songbird, 'SupportedCodec'); player.AudioInput(pa.array([1, 2, 3], type=pa.uint8())); player.RawPCMInput(pa.array([0.0, 0.0], type=pa.float32()), sample_rate=48000, channels=2); player.StreamInput(asyncio.StreamReader()); player.OpusPacketInput(pa.array([b'\xf8\xff\xfe'], type=pa.binary())); player.OpusPacketStreamInput(max_packets=1); assert 'opus' in player.supported_codecs()"
       - name: Upload wheels
@@ -307,10 +305,10 @@ jobs:
         run: uv sync --all-extras --dev --no-install-project --python "$pythonLocation/bin/python"
       - name: Test sdist
         run: |
-          uv run --no-sync python -m pip install dist/*.tar.gz
+          uv pip install dist/*.tar.gz
       - name: Test sdist minimal codec build
         run: |
-          uv run --no-sync python -m pip install --force-reinstall dist/*.tar.gz --config-settings="maturin.build-args=--no-default-features --features codec-minimal"
+          uv pip install --reinstall dist/*.tar.gz --config-settings="maturin.build-args=--no-default-features --features codec-minimal"
       - name: Upload sdist
         uses: actions/upload-artifact@v4
         with:


### PR DESCRIPTION
## Summary
- Remove low-priority manylinux s390x and ppc64le release targets.
- Switch wheel and sdist smoke installs from python -m pip to uv pip install.
- Avoid the macOS maturin-action PEP 668 failure by setting PIP_BREAK_SYSTEM_PACKAGES for that action and disabling sccache there.

## Verification
- ruby -e 'require "yaml"; YAML.load_file(".github/workflows/release.yml")'
- uv sync --all-extras --dev --no-install-project --frozen
- cargo fmt --all -- --check
- PYO3_PYTHON="/Users/sizumita/.codex/worktrees/2b91/discord-ext-songbird/.venv/bin/python" cargo clippy --all-features --all-targets
- uv run --no-sync ruff check
- uv run --no-sync ruff format --diff
- uv run --no-sync ty check
- uv run --no-sync maturin sdist --out /private/tmp/discord-ext-songbird-dist
- uv pip install --dry-run /private/tmp/discord-ext-songbird-dist/*.tar.gz
- uv pip install --dry-run --reinstall /private/tmp/discord-ext-songbird-dist/*.tar.gz --config-settings="maturin.build-args=--no-default-features --features codec-minimal"