### PR TITLE
[codex] Test release builds on master

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -2,11 +2,16 @@ name: Release CI
 on:
   workflow_dispatch:
   push:
+    branches:
+      - master
     tags:
       - "v*"
 
 permissions:
   contents: read
+
+env:
+  CARGO_NET_RETRY: "10"
 
 jobs:
   linux:
@@ -62,7 +67,7 @@ jobs:
           container: "ghcr.io/rust-cross/manylinux_2_28-cross:${{ matrix.platform.target }}"
           before-script-linux: |
             sudo apt-get update
-            sudo apt-get install -y libopus-dev
+            sudo apt-get install -y libopus-dev pkg-config
 
       - name: Smoke test native wheel
         if: matrix.platform.target == 'x86_64'


### PR DESCRIPTION
## Summary
- Run the release build matrix on pushes to `master` without publishing a release.
- Keep the publish/release job gated to tag pushes or manual `workflow_dispatch` runs.
- Harden release build jobs by increasing Cargo network retries and installing `pkg-config` in the manylinux container so `libopus_sys` can find system Opus.

## Validation
- `git diff --check`
- `ruby -e 'require "yaml"; YAML.load_file(".github/workflows/release.yml")'`

## Notes
- `act` was not run locally because it is not installed here and the Docker daemon is not available in this environment.