### PR TITLE
[codex] Fix manylinux release wheel container

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -21,8 +21,10 @@ jobs:
         platform:
           - runner: ubuntu-22.04
             target: x86_64
+            container: quay.io/pypa/manylinux_2_28_x86_64:latest
           - runner: ubuntu-22.04
             target: aarch64
+            container: ghcr.io/rust-cross/manylinux_2_28-cross:aarch64
         python-version:
           - 3.14
           - 3.14t
@@ -64,10 +66,14 @@ jobs:
           args: --release --out dist -i ${{ matrix.python-version }}
           sccache: 'true'
           manylinux: manylinux_2_28
-          container: "ghcr.io/rust-cross/manylinux_2_28-cross:${{ matrix.platform.target }}"
+          container: ${{ matrix.platform.container }}
           before-script-linux: |
-            sudo apt-get update
-            sudo apt-get install -y libopus-dev pkg-config
+            if command -v dnf >/dev/null 2>&1; then
+              dnf install -y opus-devel pkgconf-pkg-config
+            else
+              apt-get update
+              apt-get install -y libopus-dev pkg-config
+            fi
 
       - name: Smoke test native wheel
         if: matrix.platform.target == 'x86_64'


### PR DESCRIPTION
## Summary
- Use the official `manylinux_2_28_x86_64` image for x86_64 Linux release wheels.
- Keep the existing rust-cross image for aarch64 release wheels.
- Install Opus development packages via `dnf` in manylinux images, with the existing `apt-get` path kept as a fallback.

## Root Cause
The x86_64 Linux release job installed Ubuntu/Jammy `libopus-dev` inside the build container. The resulting wheel linked symbols newer than the `manylinux_2_28` policy allows, causing maturin's manylinux compliance check to fail.

## Validation
- `ruby -e 'require "yaml"; YAML.load_file(".github/workflows/release.yml"); puts "release.yml syntax ok"'`
- `git diff --check`
- `act` release job slice for Linux x86_64 / CPython 3.14: Opus packages installed via `dnf`, the `manylinux_2_28_x86_64` wheel was built, and the native wheel smoke test passed. The local `act` run only failed afterward at `actions/upload-artifact@v4` because no GitHub Actions artifact runtime token/server is available locally.